### PR TITLE
feat(serialize): add `/serialize` package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 /.husky/ @RealShadowNova
 /.vscode/ @RealShadowNova
 /.yarn/ @RealShadowNova
-/packages/auto-ensure/ @RealShadowNova
+/packages/serialize/ @RealShadowNova
 /scripts/ @RealShadowNova
 LICENSE @eslachance
 package.json @RealShadowNova

--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@
 
 **Packages**
 
+[![npm](https://img.shields.io/npm/v/@joshdb/serialize?color=crimson&logo=npm&style=flat-square&label=@joshdb/serialize)](https://www.npmjs.com/package/@joshdb/serialize)
+
 </div>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "clean": "rimraf benchmarks/dist \"packages/**/dist\" \"packages/**/node_modules/.cache\"",
     "generate": "node scripts/generate/generate.mjs",
-    "lint": "eslint packages scripts --ext mjs,ts --fix",
-    "format": "prettier --write \"{packages,scripts}/**/*.{mjs,ts}\"",
+    "lint": "eslint packages --ext mjs,ts --fix",
+    "format": "prettier --write \"packages/**/*.{mjs,ts}\"",
     "test": "yarn workspaces foreach -v --no-private run test",
     "build": "yarn workspaces foreach -v --no-private run build",
     "update": "yarn upgrade-interactive",

--- a/packages/serialize/jest.config.ts
+++ b/packages/serialize/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from '@jest/types';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export default async (): Promise<Config.InitialOptions> => ({
+  displayName: 'unit test',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRunner: 'jest-circus/runner',
+  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.base.json'
+    }
+  }
+});

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -2,7 +2,10 @@
   "name": "@joshdb/serialize",
   "version": "1.0.0",
   "description": "A serialize utility to be able to convert nodejs data types into a json compatible format",
-  "author": "@joshdb",
+  "author": "Évelyne Lachance <eslachance@gmail.com> (https://evie.codes/)",
+  "contributors": [
+    "Hezekiah Hendry <real.shadow.nova@gmail.com>"
+  ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "browser": "dist/index.umd.js",

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@joshdb/serialize",
+  "version": "1.0.0",
+  "description": "A serialize utility to be able to convert nodejs data types into a json compatible format",
+  "author": "@joshdb",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "browser": "dist/index.umd.js",
+  "unpkg": "dist/index.umd.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src tests --ext ts --fix -c ../../.eslintrc",
+    "build": "rollup -c rollup.bundle.ts",
+    "release": "npm publish",
+    "prepublishOnly": "rollup-type-bundler"
+  },
+  "devDependencies": {
+    "@favware/rollup-type-bundler": "^1.0.7",
+    "jest": "^27.5.1",
+    "rollup": "^2.68.0",
+    "rollup-plugin-cleaner": "^1.0.0",
+    "rollup-plugin-typescript2": "^0.31.2",
+    "rollup-plugin-version-injector": "^1.3.3",
+    "standard-version": "^9.3.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/josh-development/middlewares.git"
+  },
+  "files": [
+    "dist",
+    "!dist/*.tsbuildinfo"
+  ],
+  "engines": {
+    "node": ">=16.6.0",
+    "npm": ">=7"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/josh-development/middlewares/issues"
+  },
+  "homepage": "https://josh.evie.dev",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/serialize/rollup.bundle.ts
+++ b/packages/serialize/rollup.bundle.ts
@@ -1,0 +1,31 @@
+import { resolve } from 'path';
+import cleaner from 'rollup-plugin-cleaner';
+import typescript from 'rollup-plugin-typescript2';
+import versionInjector from 'rollup-plugin-version-injector';
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: './dist/index.js',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true
+    },
+    {
+      file: './dist/index.mjs',
+      format: 'es',
+      exports: 'named',
+      sourcemap: true
+    },
+    {
+      file: './dist/index.umd.js',
+      format: 'umd',
+      name: 'Serialize',
+      sourcemap: true,
+      globals: {}
+    }
+  ],
+  external: [],
+  plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') }), versionInjector()]
+};

--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/toJSON';
+export * from './lib/toRaw';
+export * from './lib/types';
+
+export const version = '[VI]{version}[/VI]';

--- a/packages/serialize/src/lib/private/index.ts
+++ b/packages/serialize/src/lib/private/index.ts
@@ -1,0 +1,1 @@
+export * from '../private/isObject';

--- a/packages/serialize/src/lib/private/isObject.ts
+++ b/packages/serialize/src/lib/private/isObject.ts
@@ -1,0 +1,3 @@
+export function isObject<Value = unknown>(value: unknown): value is Record<PropertyKey, Value> {
+  return typeof value === 'object' && value?.constructor === Object;
+}

--- a/packages/serialize/src/lib/toJSON.ts
+++ b/packages/serialize/src/lib/toJSON.ts
@@ -1,0 +1,31 @@
+import { isObject } from './private';
+import { SerializeJSON, SerializeType } from './types';
+
+export function toJSON(data: unknown): SerializeJSON {
+  if (Array.isArray(data)) return { type: SerializeType.Array, value: toJSONArray(data) };
+  else if (typeof data === 'bigint') return { type: SerializeType.BigInt, value: data.toString() };
+  else if (typeof data === 'boolean') return { type: SerializeType.Boolean, value: data };
+  else if (data instanceof Date) return { type: SerializeType.Date, value: data.toJSON() };
+  else if (data instanceof Map) return { type: SerializeType.Map, value: toJSONEntries(Array.from(data)) };
+  else if (data === null) return { type: SerializeType.Null, value: null };
+  else if (typeof data === 'number') return { type: SerializeType.Number, value: data };
+  else if (isObject(data)) return { type: SerializeType.Object, value: toJSONObject(data) };
+  else if (data instanceof RegExp) return { type: SerializeType.RegExp, value: { source: data.source, flags: data.flags } };
+  else if (data instanceof Set) return { type: SerializeType.Set, value: toJSONArray(Array.from(data)) };
+  else if (typeof data === 'string') return { type: SerializeType.String, value: data };
+  else if (data === undefined) return { type: SerializeType.Undefined, value: 'undefined' };
+
+  throw new TypeError('Serialize received an unknown type while formatting.');
+}
+
+function toJSONArray(array: unknown[]): SerializeJSON[] {
+  return array.reduce<SerializeJSON[]>((json, value) => [...json, toJSON(value)], []);
+}
+
+function toJSONEntries(entries: [PropertyKey, unknown][]): [PropertyKey, SerializeJSON][] {
+  return entries.reduce<[PropertyKey, SerializeJSON][]>((json, [key, value]) => [...json, [key, toJSON(value)]], []);
+}
+
+function toJSONObject(object: Record<PropertyKey, unknown>): Record<PropertyKey, SerializeJSON> {
+  return Object.entries(object).reduce<Record<PropertyKey, SerializeJSON>>((json, [key, value]) => ({ ...json, [key]: toJSON(value) }), {});
+}

--- a/packages/serialize/src/lib/toRaw.ts
+++ b/packages/serialize/src/lib/toRaw.ts
@@ -1,0 +1,58 @@
+import { SerializeJSON, SerializeType } from './types';
+
+export function toRaw(json: SerializeJSON): unknown {
+  const { type, value } = json;
+
+  switch (type) {
+    case SerializeType.Array:
+      return toRawArray(value as SerializeJSON[]);
+
+    case SerializeType.BigInt:
+      return BigInt(value as string);
+
+    case SerializeType.Boolean:
+      return value;
+
+    case SerializeType.Date:
+      return new Date(value as string);
+
+    case SerializeType.Map:
+      return new Map(toRawMap(value as [PropertyKey, SerializeJSON][]));
+
+    case SerializeType.Null:
+      return null;
+
+    case SerializeType.Number:
+      return value;
+
+    case SerializeType.Object:
+      return toRawObject(value as Record<PropertyKey, SerializeJSON>);
+
+    case SerializeType.RegExp:
+      return new RegExp((value as { source: string; flags: string }).source, (value as { source: string; flags: string }).flags);
+
+    case SerializeType.Set:
+      return new Set(toRawArray(value as SerializeJSON[]));
+
+    case SerializeType.String:
+      return value;
+
+    case SerializeType.Undefined:
+      return undefined;
+
+    default:
+      throw new TypeError('Serialize received an unknown type');
+  }
+}
+
+function toRawArray(json: SerializeJSON[]): unknown[] {
+  return json.reduce<unknown[]>((raw, value) => [...raw, toRaw(value)], []);
+}
+
+function toRawMap(json: [PropertyKey, SerializeJSON][]): [PropertyKey, unknown][] {
+  return json.reduce<[PropertyKey, unknown][]>((raw, [key, value]) => [...raw, [key, toRaw(value)]], []);
+}
+
+function toRawObject(json: Record<PropertyKey, SerializeJSON>): Record<PropertyKey, unknown> {
+  return Object.entries(json).reduce<Record<PropertyKey, unknown>>((raw, [key, value]) => ({ ...raw, [key]: toRaw(value) }), {});
+}

--- a/packages/serialize/src/lib/types/SerializeJSON.ts
+++ b/packages/serialize/src/lib/types/SerializeJSON.ts
@@ -1,0 +1,27 @@
+import type { SerializeType } from './SerializeType';
+
+/**
+ * The json format type interface.
+ * @since 2.0.0
+ */
+export interface SerializeJSON {
+  /**
+   * The type of {@link SerializeJSON.value}
+   * @since 2.0.0
+   */
+  type: SerializeType;
+
+  /**
+   * The value for this json.
+   * @since 2.0.0
+   */
+  value:
+    | string
+    | number
+    | boolean
+    | null
+    | SerializeJSON[]
+    | [PropertyKey, SerializeJSON][]
+    | Record<PropertyKey, SerializeJSON>
+    | { source: string; flags: string };
+}

--- a/packages/serialize/src/lib/types/SerializeType.ts
+++ b/packages/serialize/src/lib/types/SerializeType.ts
@@ -1,0 +1,25 @@
+export enum SerializeType {
+  Array = 'array',
+
+  BigInt = 'bigint',
+
+  Boolean = 'boolean',
+
+  Date = 'date',
+
+  Map = 'map',
+
+  Null = 'null',
+
+  Number = 'number',
+
+  Object = 'object',
+
+  RegExp = 'regexp',
+
+  Set = 'set',
+
+  String = 'string',
+
+  Undefined = 'undefined'
+}

--- a/packages/serialize/src/lib/types/index.ts
+++ b/packages/serialize/src/lib/types/index.ts
@@ -1,0 +1,2 @@
+export * from './SerializeJSON';
+export * from './SerializeType';

--- a/packages/serialize/src/tsconfig.json
+++ b/packages/serialize/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "../dist",
+    "composite": true,
+    "preserveConstEnums": true,
+    "useDefineForClassFields": false
+  },
+  "include": ["."]
+}

--- a/packages/serialize/tests/lib/toJSON.test.ts
+++ b/packages/serialize/tests/lib/toJSON.test.ts
@@ -1,0 +1,314 @@
+import { SerializeType, toJSON } from '../../src';
+
+describe('toJSON', () => {
+  test('GIVEN typeof toJSON THEN returns functions', () => {
+    expect(typeof toJSON).toBe('function');
+  });
+
+  describe('can format raw data', () => {
+    const rawBigInt = 0n;
+    const rawBoolean = false;
+    const rawDate = new Date();
+    const rawNull = null;
+    const rawNumber = 0;
+    const rawRegExp = /test/g;
+    const rawString = 'test';
+    const rawUndefined = undefined;
+    const jsonBigInt = rawBigInt.toString();
+    const jsonBoolean = rawBoolean;
+    const jsonDate = rawDate.toJSON();
+    const jsonNull = rawNull;
+    const jsonNumber = rawNumber;
+    const jsonRegExp = { source: rawRegExp.source, flags: rawRegExp.flags };
+    const jsonString = rawString;
+    const jsonUndefined = `${rawUndefined}`;
+
+    describe(SerializeType.Array, () => {
+      test(SerializeType.BigInt, () => {
+        const { type, value } = toJSON([rawBigInt]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.BigInt, value: jsonBigInt }]);
+      });
+
+      test(SerializeType.Boolean, () => {
+        const { type, value } = toJSON([rawBoolean]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.Boolean, value: jsonBoolean }]);
+      });
+
+      test(SerializeType.Date, () => {
+        const { type, value } = toJSON([rawDate]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.Date, value: jsonDate }]);
+      });
+
+      test(SerializeType.Null, () => {
+        const { type, value } = toJSON([rawNull]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.Null, value: jsonNull }]);
+      });
+
+      test(SerializeType.Number, () => {
+        const { type, value } = toJSON([rawNumber]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.Number, value: jsonNumber }]);
+      });
+
+      test(SerializeType.RegExp, () => {
+        const { type, value } = toJSON([rawRegExp]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.RegExp, value: jsonRegExp }]);
+      });
+
+      test(SerializeType.String, () => {
+        const { type, value } = toJSON([rawString]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.String, value: jsonString }]);
+      });
+
+      test(SerializeType.Undefined, () => {
+        const { type, value } = toJSON([rawUndefined]);
+
+        expect(type).toBe(SerializeType.Array);
+        expect(value).toStrictEqual([{ type: SerializeType.Undefined, value: jsonUndefined }]);
+      });
+    });
+
+    test(SerializeType.BigInt, () => {
+      const { type, value } = toJSON(rawBigInt);
+
+      expect(type).toBe(SerializeType.BigInt);
+      expect(value).toStrictEqual(jsonBigInt);
+    });
+
+    test(SerializeType.Boolean, () => {
+      const { type, value } = toJSON(rawBoolean);
+
+      expect(type).toBe(SerializeType.Boolean);
+      expect(value).toStrictEqual(jsonBoolean);
+    });
+
+    test(SerializeType.Date, () => {
+      const { type, value } = toJSON(rawDate);
+
+      expect(type).toBe(SerializeType.Date);
+      expect(value).toStrictEqual(jsonDate);
+    });
+
+    describe(SerializeType.Map, () => {
+      test(SerializeType.BigInt, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawBigInt]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.BigInt, value: jsonBigInt }]]);
+      });
+
+      test(SerializeType.Boolean, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawBoolean]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.Boolean, value: jsonBoolean }]]);
+      });
+
+      test(SerializeType.Date, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawDate]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.Date, value: jsonDate }]]);
+      });
+
+      test(SerializeType.Null, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawNull]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.Null, value: jsonNull }]]);
+      });
+
+      test(SerializeType.Number, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawNumber]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.Number, value: jsonNumber }]]);
+      });
+
+      test(SerializeType.RegExp, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawRegExp]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.RegExp, value: jsonRegExp }]]);
+      });
+
+      test(SerializeType.String, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawString]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.String, value: jsonString }]]);
+      });
+
+      test(SerializeType.Undefined, () => {
+        const { type, value } = toJSON(new Map([['test:key', rawUndefined]]));
+
+        expect(type).toBe(SerializeType.Map);
+        expect(value).toStrictEqual([['test:key', { type: SerializeType.Undefined, value: jsonUndefined }]]);
+      });
+    });
+
+    test(SerializeType.Null, () => {
+      const { type, value } = toJSON(rawNull);
+
+      expect(type).toBe(SerializeType.Null);
+      expect(value).toStrictEqual(jsonNull);
+    });
+
+    test(SerializeType.Number, () => {
+      const { type, value } = toJSON(rawNumber);
+
+      expect(type).toBe(SerializeType.Number);
+      expect(value).toStrictEqual(jsonNumber);
+    });
+
+    describe(SerializeType.Object, () => {
+      test(SerializeType.BigInt, () => {
+        const { type, value } = toJSON({ key: rawBigInt });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.BigInt, value: jsonBigInt } });
+      });
+
+      test(SerializeType.Boolean, () => {
+        const { type, value } = toJSON({ key: rawBoolean });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.Boolean, value: jsonBoolean } });
+      });
+
+      test(SerializeType.Date, () => {
+        const { type, value } = toJSON({ key: rawDate });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.Date, value: jsonDate } });
+      });
+
+      test(SerializeType.Null, () => {
+        const { type, value } = toJSON({ key: rawNull });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.Null, value: jsonNull } });
+      });
+
+      test(SerializeType.Number, () => {
+        const { type, value } = toJSON({ key: rawNumber });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.Number, value: jsonNumber } });
+      });
+
+      test(SerializeType.RegExp, () => {
+        const { type, value } = toJSON({ key: rawRegExp });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.RegExp, value: jsonRegExp } });
+      });
+
+      test(SerializeType.String, () => {
+        const { type, value } = toJSON({ key: rawString });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.String, value: jsonString } });
+      });
+
+      test(SerializeType.Undefined, () => {
+        const { type, value } = toJSON({ key: rawUndefined });
+
+        expect(type).toBe(SerializeType.Object);
+        expect(value).toStrictEqual({ key: { type: SerializeType.Undefined, value: jsonUndefined } });
+      });
+    });
+
+    test(SerializeType.RegExp, () => {
+      const { type, value } = toJSON(rawRegExp);
+
+      expect(type).toBe(SerializeType.RegExp);
+      expect(value).toStrictEqual(jsonRegExp);
+    });
+
+    describe(SerializeType.Set, () => {
+      test(SerializeType.BigInt, () => {
+        const { type, value } = toJSON(new Set([rawBigInt]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.BigInt, value: jsonBigInt }]);
+      });
+
+      test(SerializeType.Boolean, () => {
+        const { type, value } = toJSON(new Set([rawBoolean]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.Boolean, value: jsonBoolean }]);
+      });
+
+      test(SerializeType.Date, () => {
+        const { type, value } = toJSON(new Set([rawDate]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.Date, value: jsonDate }]);
+      });
+
+      test(SerializeType.Null, () => {
+        const { type, value } = toJSON(new Set([rawNull]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.Null, value: jsonNull }]);
+      });
+
+      test(SerializeType.Number, () => {
+        const { type, value } = toJSON(new Set([rawNumber]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.Number, value: jsonNumber }]);
+      });
+
+      test(SerializeType.RegExp, () => {
+        const { type, value } = toJSON(new Set([rawRegExp]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.RegExp, value: jsonRegExp }]);
+      });
+
+      test(SerializeType.String, () => {
+        const { type, value } = toJSON(new Set([rawString]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.String, value: jsonString }]);
+      });
+
+      test(SerializeType.Undefined, () => {
+        const { type, value } = toJSON(new Set([rawUndefined]));
+
+        expect(type).toBe(SerializeType.Set);
+        expect(value).toStrictEqual([{ type: SerializeType.Undefined, value: jsonUndefined }]);
+      });
+    });
+
+    test(SerializeType.String, () => {
+      const { type, value } = toJSON(rawString);
+
+      expect(type).toBe(SerializeType.String);
+      expect(value).toStrictEqual(jsonString);
+    });
+
+    test(SerializeType.Undefined, () => {
+      const { type, value } = toJSON(rawUndefined);
+
+      expect(type).toBe(SerializeType.Undefined);
+      expect(value).toStrictEqual(jsonUndefined);
+    });
+  });
+});

--- a/packages/serialize/tests/lib/toRaw.test.ts
+++ b/packages/serialize/tests/lib/toRaw.test.ts
@@ -1,0 +1,228 @@
+import { SerializeType, toRaw } from '../../src';
+
+describe('toRaw', () => {
+  test('GIVEN typeof toRaw THEN returns function', () => {
+    expect(typeof toRaw).toBe('function');
+  });
+
+  describe('can parse json data', () => {
+    const rawBigInt = 0n;
+    const rawBoolean = false;
+    const rawDate = new Date();
+    const rawNull = null;
+    const rawNumber = 0;
+    const rawRegExp = /test/g;
+    const rawString = 'test';
+    const rawUndefined = undefined;
+    const jsonBigInt = rawBigInt.toString();
+    const jsonBoolean = rawBoolean;
+    const jsonDate = rawDate.toJSON();
+    const jsonNull = rawNull;
+    const jsonNumber = rawNumber;
+    const jsonRegExp = { source: rawRegExp.source, flags: rawRegExp.flags };
+    const jsonString = rawString;
+    const jsonUndefined = `${rawUndefined}`;
+
+    describe(SerializeType.Array, () => {
+      test(SerializeType.BigInt, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.BigInt, value: jsonBigInt }] })).toStrictEqual([rawBigInt]);
+      });
+
+      test(SerializeType.Boolean, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.Boolean, value: jsonBoolean }] })).toStrictEqual([rawBoolean]);
+      });
+
+      test(SerializeType.Date, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.Date, value: jsonDate }] })).toStrictEqual([rawDate]);
+      });
+
+      test(SerializeType.Null, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.Null, value: jsonNull }] })).toStrictEqual([rawNull]);
+      });
+
+      test(SerializeType.Number, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.Number, value: jsonNumber }] })).toStrictEqual([rawNumber]);
+      });
+
+      test(SerializeType.RegExp, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.RegExp, value: jsonRegExp }] })).toStrictEqual([rawRegExp]);
+      });
+
+      test(SerializeType.String, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.String, value: jsonString }] })).toStrictEqual([rawString]);
+      });
+
+      test(SerializeType.Undefined, () => {
+        expect(toRaw({ type: SerializeType.Array, value: [{ type: SerializeType.Undefined, value: jsonUndefined }] })).toStrictEqual([rawUndefined]);
+      });
+    });
+
+    test(SerializeType.BigInt, () => {
+      expect(toRaw({ type: SerializeType.BigInt, value: jsonBigInt })).toBe(rawBigInt);
+    });
+
+    test(SerializeType.Boolean, () => {
+      expect(toRaw({ type: SerializeType.Boolean, value: jsonBoolean })).toBe(rawBoolean);
+    });
+
+    test(SerializeType.Date, () => {
+      expect(toRaw({ type: SerializeType.Date, value: jsonDate })).toStrictEqual(rawDate);
+    });
+
+    describe(SerializeType.Map, () => {
+      test(SerializeType.BigInt, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.BigInt, value: jsonBigInt }]] })).toStrictEqual(
+          new Map([['key', rawBigInt]])
+        );
+      });
+
+      test(SerializeType.Boolean, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.Boolean, value: jsonBoolean }]] })).toStrictEqual(
+          new Map([['key', rawBoolean]])
+        );
+      });
+
+      test(SerializeType.Date, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.Date, value: jsonDate }]] })).toStrictEqual(
+          new Map([['key', rawDate]])
+        );
+      });
+
+      test(SerializeType.Null, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.Null, value: jsonNull }]] })).toStrictEqual(
+          new Map([['key', rawNull]])
+        );
+      });
+
+      test(SerializeType.Number, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.Number, value: jsonNumber }]] })).toStrictEqual(
+          new Map([['key', rawNumber]])
+        );
+      });
+
+      test(SerializeType.RegExp, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.RegExp, value: jsonRegExp }]] })).toStrictEqual(
+          new Map([['key', rawRegExp]])
+        );
+      });
+
+      test(SerializeType.String, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.String, value: jsonString }]] })).toStrictEqual(
+          new Map([['key', rawString]])
+        );
+      });
+
+      test(SerializeType.Undefined, () => {
+        expect(toRaw({ type: SerializeType.Map, value: [['key', { type: SerializeType.Undefined, value: jsonUndefined }]] })).toStrictEqual(
+          new Map([['key', rawUndefined]])
+        );
+      });
+    });
+
+    test(SerializeType.Null, () => {
+      expect(toRaw({ type: SerializeType.Null, value: jsonNull })).toBe(rawNull);
+    });
+
+    test(SerializeType.Number, () => {
+      expect(toRaw({ type: SerializeType.Number, value: jsonNumber })).toBe(rawNumber);
+    });
+
+    describe(SerializeType.Object, () => {
+      test(SerializeType.BigInt, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.BigInt, value: jsonBigInt } } })).toStrictEqual({
+          key: rawBigInt
+        });
+      });
+
+      test(SerializeType.Boolean, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.Boolean, value: jsonBoolean } } })).toStrictEqual({
+          key: rawBoolean
+        });
+      });
+
+      test(SerializeType.Date, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.Date, value: jsonDate } } })).toStrictEqual({
+          key: rawDate
+        });
+      });
+
+      test(SerializeType.Null, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.Null, value: jsonNull } } })).toStrictEqual({
+          key: rawNull
+        });
+      });
+
+      test(SerializeType.Number, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.Number, value: jsonNumber } } })).toStrictEqual({
+          key: rawNumber
+        });
+      });
+
+      test(SerializeType.RegExp, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.RegExp, value: jsonRegExp } } })).toStrictEqual({
+          key: rawRegExp
+        });
+      });
+
+      test(SerializeType.String, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.String, value: jsonString } } })).toStrictEqual({
+          key: rawString
+        });
+      });
+
+      test(SerializeType.Undefined, () => {
+        expect(toRaw({ type: SerializeType.Object, value: { key: { type: SerializeType.Undefined, value: jsonUndefined } } })).toStrictEqual({
+          key: rawUndefined
+        });
+      });
+    });
+
+    test(SerializeType.RegExp, () => {
+      expect(toRaw({ type: SerializeType.RegExp, value: jsonRegExp })).toStrictEqual(rawRegExp);
+    });
+
+    describe(SerializeType.Set, () => {
+      test(SerializeType.BigInt, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.BigInt, value: jsonBigInt }] })).toStrictEqual(new Set([rawBigInt]));
+      });
+
+      test(SerializeType.Boolean, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.Boolean, value: jsonBoolean }] })).toStrictEqual(new Set([rawBoolean]));
+      });
+
+      test(SerializeType.Date, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.Date, value: jsonDate }] })).toStrictEqual(new Set([rawDate]));
+      });
+
+      test(SerializeType.Null, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.Null, value: jsonNull }] })).toStrictEqual(new Set([rawNull]));
+      });
+
+      test(SerializeType.Number, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.Number, value: jsonNumber }] })).toStrictEqual(new Set([rawNumber]));
+      });
+
+      test(SerializeType.RegExp, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.RegExp, value: jsonRegExp }] })).toStrictEqual(new Set([rawRegExp]));
+      });
+
+      test(SerializeType.String, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.String, value: jsonString }] })).toStrictEqual(new Set([rawString]));
+      });
+
+      test(SerializeType.Undefined, () => {
+        expect(toRaw({ type: SerializeType.Set, value: [{ type: SerializeType.Undefined, value: jsonUndefined }] })).toStrictEqual(
+          new Set([rawUndefined])
+        );
+      });
+    });
+
+    test(SerializeType.String, () => {
+      expect(toRaw({ type: SerializeType.String, value: jsonString })).toBe(rawString);
+    });
+
+    test(SerializeType.Undefined, () => {
+      expect(toRaw({ type: SerializeType.Undefined, value: jsonUndefined })).toBe(rawUndefined);
+    });
+  });
+});

--- a/packages/serialize/tests/tsconfig.json
+++ b/packages/serialize/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.base.json"
+}

--- a/packages/serialize/tsconfig.base.json
+++ b/packages/serialize/tsconfig.base.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/serialize/tsconfig.eslint.json
+++ b/packages/serialize/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  },
+  "include": ["src", "tests"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,6 +631,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@favware/rollup-type-bundler@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@favware/rollup-type-bundler@npm:1.0.7"
+  dependencies:
+    "@sapphire/utilities": ^3.1.0
+    colorette: ^2.0.16
+    commander: ^8.3.0
+    js-yaml: ^4.1.0
+    rollup: ^2.63.0
+    rollup-plugin-dts: ^4.1.0
+    typescript: ^4.5.4
+  bin:
+    rollup-type-bundler: dist/cli.js
+    rtb: dist/cli.js
+  checksum: e42a8c5b4509b78219b477acdd36baedfb97e48265796e3418baba085d0f9e65ce7ccab59c011a4eb320bcf778dfda8ff2a257910044846b02c2ca00baee73ec
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -653,6 +671,13 @@ __metadata:
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+  languageName: node
+  linkType: hard
+
+"@hutson/parse-repository-url@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@hutson/parse-repository-url@npm:3.0.2"
+  checksum: 39992c5f183c5ca3d761d6ed9dfabcb79b5f3750bf1b7f3532e1dc439ca370138bbd426ee250fdaba460bc948e6761fbefd484b8f4f36885d71ded96138340d1
   languageName: node
   linkType: hard
 
@@ -877,6 +902,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@joshdb/serialize@workspace:packages/serialize":
+  version: 0.0.0-use.local
+  resolution: "@joshdb/serialize@workspace:packages/serialize"
+  dependencies:
+    "@favware/rollup-type-bundler": ^1.0.7
+    jest: ^27.5.1
+    rollup: ^2.68.0
+    rollup-plugin-cleaner: ^1.0.0
+    rollup-plugin-typescript2: ^0.31.2
+    rollup-plugin-version-injector: ^1.3.3
+    standard-version: ^9.3.2
+  languageName: unknown
+  linkType: soft
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -1029,7 +1068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/utilities@npm:^3.0.1":
+"@sapphire/utilities@npm:^3.0.1, @sapphire/utilities@npm:^3.1.0":
   version: 3.6.2
   resolution: "@sapphire/utilities@npm:3.6.2"
   checksum: 71210753b446f3f2835dd9d28fb10767f4c6f005b465eea179082d9f2c071acb7dcd2aebdf7c4974b26aad3ab2374a1dd168a66371b06bd65f248bbca4a90cda
@@ -1482,6 +1521,13 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: aca0aabf98826717920ac2583fdcad0a6fbe4e583fdb6e843af2594e907455aeafe30b1e14f1757cd83ce1776773cf8296ffc3a4acf13f0bd3dfebcf1db6ae80
+  languageName: node
+  linkType: hard
+
+"add-stream@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "add-stream@npm:1.0.0"
+  checksum: 3e9e8b0b8f0170406d7c3a9a39bfbdf419ccccb0fd2a396338c0fda0a339af73bf738ad414fc520741de74517acf0dd92b4a36fd3298a47fd5371eee8f2c5a06
   languageName: node
   linkType: hard
 
@@ -1938,7 +1984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0":
+"chalk@npm:^2.0.0, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -2146,6 +2192,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concat-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "concat-stream@npm:2.0.0"
+  dependencies:
+    buffer-from: ^1.0.0
+    inherits: ^2.0.3
+    readable-stream: ^3.0.2
+    typedarray: ^0.0.6
+  checksum: d7f75d48f0ecd356c1545d87e22f57b488172811b1181d96021c7c4b14ab8855f5313280263dca44bb06e5222f274d047da3e290a38841ef87b59719bde967c7
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
@@ -2153,7 +2211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^5.0.11":
+"conventional-changelog-angular@npm:^5.0.11, conventional-changelog-angular@npm:^5.0.12":
   version: 5.0.13
   resolution: "conventional-changelog-angular@npm:5.0.13"
   dependencies:
@@ -2163,7 +2221,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:^4.3.1":
+"conventional-changelog-atom@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "conventional-changelog-atom@npm:2.0.8"
+  dependencies:
+    q: ^1.5.1
+  checksum: 12ecbd928f8c261f9afaac067fcc0cf10ff6ac8505e4285dc3d9959ee072a8937ac942d505e850dce27c4527046009adb22b498ba0b10802916d2c7d2dc1f7bc
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-codemirror@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "conventional-changelog-codemirror@npm:2.0.8"
+  dependencies:
+    q: ^1.5.1
+  checksum: cf331db40cc54c2353b0189aba26a2b959cb08b059bf2a81245272027371519c9acc90d574295782985829c50f0c52da60c952c70ec6dbd70e9e17affeb61453
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-config-spec@npm:2.1.0":
+  version: 2.1.0
+  resolution: "conventional-changelog-config-spec@npm:2.1.0"
+  checksum: 1c3bec23e3558e25ba0f2884ef1c1266afa70084f156b90045dde654504af3d8f3e88ad1c0dd6c1aaf2f394069d6e8b39da8cab319bc2d8ca0c80e8042a8a33c
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-conventionalcommits@npm:4.6.1":
+  version: 4.6.1
+  resolution: "conventional-changelog-conventionalcommits@npm:4.6.1"
+  dependencies:
+    compare-func: ^2.0.0
+    lodash: ^4.17.15
+    q: ^1.5.1
+  checksum: f866616c8f6f21cea005b42792451bfbd16bd4d82872867d1218f67a7993a53c5d87e26d6b483d9252e8022f2e4570e6cf9fa2a409aae5a3d73eea92ccf78b13
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-conventionalcommits@npm:^4.3.1, conventional-changelog-conventionalcommits@npm:^4.5.0":
   version: 4.6.3
   resolution: "conventional-changelog-conventionalcommits@npm:4.6.3"
   dependencies:
@@ -2174,7 +2268,130 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-commits-parser@npm:^3.2.2":
+"conventional-changelog-core@npm:^4.2.1":
+  version: 4.2.4
+  resolution: "conventional-changelog-core@npm:4.2.4"
+  dependencies:
+    add-stream: ^1.0.0
+    conventional-changelog-writer: ^5.0.0
+    conventional-commits-parser: ^3.2.0
+    dateformat: ^3.0.0
+    get-pkg-repo: ^4.0.0
+    git-raw-commits: ^2.0.8
+    git-remote-origin-url: ^2.0.0
+    git-semver-tags: ^4.1.1
+    lodash: ^4.17.15
+    normalize-package-data: ^3.0.0
+    q: ^1.5.1
+    read-pkg: ^3.0.0
+    read-pkg-up: ^3.0.0
+    through2: ^4.0.0
+  checksum: 56d5194040495ea316e53fd64cb3614462c318f0fe54b1bf25aba6fba9b3d51cb9fdf7ac5b766f17e5529a3f90e317257394e00b0a9a5ce42caf3a59f82afb3a
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-ember@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "conventional-changelog-ember@npm:2.0.9"
+  dependencies:
+    q: ^1.5.1
+  checksum: 30c7bd48ce995e39fc91bcd8c719b2bee10cb408c246a6a7de6cec44a3ca12afe5a86f57f55aa1fd2c64beb484c68013d16658047e6273f130c1c80e7dad38e9
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-eslint@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "conventional-changelog-eslint@npm:3.0.9"
+  dependencies:
+    q: ^1.5.1
+  checksum: 402ae73a8c5390405d4f902819f630f56fa7dfa8f6bef77b3b5f2fb7c8bd17f64ad83edbacc030cfef5b84400ab722d4f166dd906296a4d286e66205c1bd8a3f
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-express@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "conventional-changelog-express@npm:2.0.6"
+  dependencies:
+    q: ^1.5.1
+  checksum: c139fa9878971455cce9904a195d92f770679d24a88ef07a016a6954e28f0f237ec59e45f2591b2fc9b8e10fd46c30150ddf0ce50a2cb03be85cae0ee64d4cdd
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-jquery@npm:^3.0.11":
+  version: 3.0.11
+  resolution: "conventional-changelog-jquery@npm:3.0.11"
+  dependencies:
+    q: ^1.5.1
+  checksum: df1145467c75e8e61f35ed24d7539e8b7dcdc810b86267b0173420c8955590cca139eb51f89ac255d70c632433d996b0ed227cb1acdf59537f3d2f4ad9c770d3
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-jshint@npm:^2.0.9":
+  version: 2.0.9
+  resolution: "conventional-changelog-jshint@npm:2.0.9"
+  dependencies:
+    compare-func: ^2.0.0
+    q: ^1.5.1
+  checksum: ec96144b75fdb84c4a6f7db9b671dc258d964cd7aa35f9b00539e42bbe05601a9127c17cf0dcc315ae81a0dd20fe795d9d41dd90373928d24b33f065728eb2e2
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-preset-loader@npm:^2.3.4":
+  version: 2.3.4
+  resolution: "conventional-changelog-preset-loader@npm:2.3.4"
+  checksum: 23a889b7fcf6fe7653e61f32a048877b2f954dcc1e0daa2848c5422eb908e6f24c78372f8d0d2130b5ed941c02e7010c599dccf44b8552602c6c8db9cb227453
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-writer@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "conventional-changelog-writer@npm:5.0.1"
+  dependencies:
+    conventional-commits-filter: ^2.0.7
+    dateformat: ^3.0.0
+    handlebars: ^4.7.7
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.15
+    meow: ^8.0.0
+    semver: ^6.0.0
+    split: ^1.0.0
+    through2: ^4.0.0
+  bin:
+    conventional-changelog-writer: cli.js
+  checksum: 5c0129db44577f14b1f8de225b62a392a9927ba7fe3422cb21ad71a771b8472bd03badb7c87cb47419913abc3f2ce3759b69f59550cdc6f7a7b0459015b3b44c
+  languageName: node
+  linkType: hard
+
+"conventional-changelog@npm:3.1.24":
+  version: 3.1.24
+  resolution: "conventional-changelog@npm:3.1.24"
+  dependencies:
+    conventional-changelog-angular: ^5.0.12
+    conventional-changelog-atom: ^2.0.8
+    conventional-changelog-codemirror: ^2.0.8
+    conventional-changelog-conventionalcommits: ^4.5.0
+    conventional-changelog-core: ^4.2.1
+    conventional-changelog-ember: ^2.0.9
+    conventional-changelog-eslint: ^3.0.9
+    conventional-changelog-express: ^2.0.6
+    conventional-changelog-jquery: ^3.0.11
+    conventional-changelog-jshint: ^2.0.9
+    conventional-changelog-preset-loader: ^2.3.4
+  checksum: 54253a3e3761369a8c68ec1ea57f3847b323a0104503dfccfd305553f77e83636132406d463dfa60ad3851dba42d84a528e8cb685943e8d6d7ae3eb37aaa19bb
+  languageName: node
+  linkType: hard
+
+"conventional-commits-filter@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "conventional-commits-filter@npm:2.0.7"
+  dependencies:
+    lodash.ismatch: ^4.4.0
+    modify-values: ^1.0.0
+  checksum: feb567f680a6da1baaa1ef3cff393b3c56a5828f77ab9df5e70626475425d109a6fee0289b4979223c62bbd63bf9c98ef532baa6fcb1b66ee8b5f49077f5d46c
+  languageName: node
+  linkType: hard
+
+"conventional-commits-parser@npm:^3.2.0, conventional-commits-parser@npm:^3.2.2":
   version: 3.2.4
   resolution: "conventional-commits-parser@npm:3.2.4"
   dependencies:
@@ -2190,12 +2407,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"conventional-recommended-bump@npm:6.1.0":
+  version: 6.1.0
+  resolution: "conventional-recommended-bump@npm:6.1.0"
+  dependencies:
+    concat-stream: ^2.0.0
+    conventional-changelog-preset-loader: ^2.3.4
+    conventional-commits-filter: ^2.0.7
+    conventional-commits-parser: ^3.2.0
+    git-raw-commits: ^2.0.8
+    git-semver-tags: ^4.1.1
+    meow: ^8.0.0
+    q: ^1.5.1
+  bin:
+    conventional-recommended-bump: cli.js
+  checksum: da1d7a5f3b9f7706bede685cdcb3db67997fdaa43c310fd5bf340955c84a4b85dbb9427031522ee06dad290b730a54be987b08629d79c73720dbad3a2531146b
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.8.0
   resolution: "convert-source-map@npm:1.8.0"
   dependencies:
     safe-buffer: ~5.1.1
   checksum: 985d974a2d33e1a2543ada51c93e1ba2f73eaed608dc39f229afc78f71dcc4c8b7d7c684aa647e3c6a3a204027444d69e53e169ce94e8d1fa8d7dee80c9c8fed
+  languageName: node
+  linkType: hard
+
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
   languageName: node
   linkType: hard
 
@@ -2294,6 +2536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dateformat@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "dateformat@npm:3.0.3"
+  checksum: ca4911148abb09887bd9bdcd632c399b06f3ecad709a18eb594d289a1031982f441e08e281db77ffebcb2cbcbfa1ac578a7cbfbf8743f41009aa5adc1846ed34
+  languageName: node
+  linkType: hard
+
 "dateformat@npm:^4.2.1":
   version: 4.6.3
   resolution: "dateformat@npm:4.6.3"
@@ -2379,7 +2628,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-newline@npm:^3.0.0":
+"detect-indent@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "detect-indent@npm:6.1.0"
+  checksum: ab953a73c72dbd4e8fc68e4ed4bfd92c97eb6c43734af3900add963fd3a9316f3bc0578b018b24198d4c31a358571eff5f0656e81a1f3b9ad5c547d58b2d093d
+  languageName: node
+  linkType: hard
+
+"detect-newline@npm:^3.0.0, detect-newline@npm:^3.1.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
@@ -2433,6 +2689,16 @@ __metadata:
   dependencies:
     is-obj: ^2.0.0
   checksum: d5775790093c234ef4bfd5fbe40884ff7e6c87573e5339432870616331189f7f5d86575c5b5af2dcf0f61172990f4f734d07844b1f23482fff09e3c4bead05ea
+  languageName: node
+  linkType: hard
+
+"dotgitignore@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "dotgitignore@npm:2.1.0"
+  dependencies:
+    find-up: ^3.0.0
+    minimatch: ^3.0.4
+  checksum: 67589446765ddc25539f414b7649442a649f047343030342f309ba69172beb916b9e54feb7d552db422111265f9e93344f31b5697e8e6c81ffc13d33c0d910a0
   languageName: node
   linkType: hard
 
@@ -2854,6 +3120,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"figures@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: ^1.0.5
+  checksum: 85a6ad29e9aca80b49b817e7c89ecc4716ff14e3779d9835af554db91bac41c0f289c418923519392a1e582b4d10482ad282021330cd045bb7b80c84152f2a2b
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
@@ -2880,6 +3155,24 @@ __metadata:
     make-dir: ^3.0.2
     pkg-dir: ^4.1.0
   checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "find-up@npm:2.1.0"
+  dependencies:
+    locate-path: ^2.0.0
+  checksum: 43284fe4da09f89011f08e3c32cd38401e786b19226ea440b75386c1b12a4cb738c94969808d53a84f564ede22f732c8409e3cfc3f7fb5b5c32378ad0bbf28bd
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "find-up@npm:3.0.0"
+  dependencies:
+    locate-path: ^3.0.0
+  checksum: 38eba3fe7a66e4bc7f0f5a1366dc25508b7cfc349f852640e3678d26ad9a6d7e2c43eff0a472287de4a9753ef58f066a0ea892a256fa3636ad51b3fe1e17fae9
   languageName: node
   linkType: hard
 
@@ -2931,6 +3224,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-access@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "fs-access@npm:1.0.1"
+  dependencies:
+    null-check: ^1.0.0
+  checksum: 6792b115a5fc5095b3dbc42ea329afff372e0056fde8214a5b0c9c7559806378db9316660bac1682b295cc576bab3c19571f50f8a39ab4605c3d194bee0087c9
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^10.0.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
@@ -2958,7 +3260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -2968,7 +3270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
@@ -3028,6 +3330,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-pkg-repo@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "get-pkg-repo@npm:4.2.1"
+  dependencies:
+    "@hutson/parse-repository-url": ^3.0.0
+    hosted-git-info: ^4.0.0
+    through2: ^2.0.0
+    yargs: ^16.2.0
+  bin:
+    get-pkg-repo: src/cli.js
+  checksum: 5abf169137665e45b09a857b33ad2fdcf2f4a09f0ecbd0ebdd789a7ce78c39186a21f58621127eb724d2d4a3a7ee8e6bd4ac7715efda01ad5200665afc218e0d
+  languageName: node
+  linkType: hard
+
 "get-stream@npm:^5.0.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
@@ -3044,7 +3360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-raw-commits@npm:^2.0.0":
+"git-raw-commits@npm:^2.0.0, git-raw-commits@npm:^2.0.8":
   version: 2.0.11
   resolution: "git-raw-commits@npm:2.0.11"
   dependencies:
@@ -3056,6 +3372,37 @@ __metadata:
   bin:
     git-raw-commits: cli.js
   checksum: c178af43633684106179793b6e3473e1d2bb50bb41d04e2e285ea4eef342ca4090fee6bc8a737552fde879d22346c90de5c49f18c719a0f38d4c934f258a0f79
+  languageName: node
+  linkType: hard
+
+"git-remote-origin-url@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "git-remote-origin-url@npm:2.0.0"
+  dependencies:
+    gitconfiglocal: ^1.0.0
+    pify: ^2.3.0
+  checksum: 85263a09c044b5f4fe2acc45cbb3c5331ab2bd4484bb53dfe7f3dd593a4bf90a9786a2e00b9884524331f50b3da18e8c924f01c2944087fc7f342282c4437b73
+  languageName: node
+  linkType: hard
+
+"git-semver-tags@npm:^4.0.0, git-semver-tags@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "git-semver-tags@npm:4.1.1"
+  dependencies:
+    meow: ^8.0.0
+    semver: ^6.0.0
+  bin:
+    git-semver-tags: cli.js
+  checksum: e16d02a515c0f88289a28b5bf59bf42c0dc053765922d3b617ae4b50546bd4f74a25bf3ad53b91cb6c1159319a2e92533b160c573b856c2629125c8b26b3b0e3
+  languageName: node
+  linkType: hard
+
+"gitconfiglocal@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "gitconfiglocal@npm:1.0.0"
+  dependencies:
+    ini: ^1.3.2
+  checksum: e6d2764c15bbab6d1d1000d1181bb907f6b3796bb04f63614dba571b18369e0ecb1beaf27ce8da5b24307ef607e3a5f262a67cb9575510b9446aac697d421beb
   languageName: node
   linkType: hard
 
@@ -3144,10 +3491,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7":
+  version: 4.7.7
+  resolution: "handlebars@npm:4.7.7"
+  dependencies:
+    minimist: ^1.2.5
+    neo-async: ^2.6.0
+    source-map: ^0.6.1
+    uglify-js: ^3.1.4
+    wordwrap: ^1.0.0
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
   languageName: node
   linkType: hard
 
@@ -3195,7 +3560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^4.0.1":
+"hosted-git-info@npm:^4.0.0, hosted-git-info@npm:^4.0.1":
   version: 4.1.0
   resolution: "hosted-git-info@npm:4.1.0"
   dependencies:
@@ -3369,14 +3734,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.4":
+"ini@npm:^1.3.2, ini@npm:^1.3.4":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
@@ -3498,6 +3863,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
+  languageName: node
+  linkType: hard
+
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
@@ -4128,6 +4500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-parse-better-errors@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "json-parse-better-errors@npm:1.0.2"
+  checksum: ff2b5ba2a70e88fd97a3cb28c1840144c5ce8fae9cbeeddba15afa333a5c407cf0e42300cd0a2885dbb055227fe68d405070faad941beeffbfde9cf3b2c78c5d
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -4146,6 +4525,13 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: cff44156ddce9c67c44386ad5cddf91925fe06b1d217f2da9c4910d01f358c6e3989c4d5a02683c7a5667f9727ff05831f7aa8ae66c8ff691c556f0884d49215
+  languageName: node
+  linkType: hard
+
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
   languageName: node
   linkType: hard
 
@@ -4278,6 +4664,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-json-file@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "load-json-file@npm:4.0.0"
+  dependencies:
+    graceful-fs: ^4.1.2
+    parse-json: ^4.0.0
+    pify: ^3.0.0
+    strip-bom: ^3.0.0
+  checksum: 8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "locate-path@npm:2.0.0"
+  dependencies:
+    p-locate: ^2.0.0
+    path-exists: ^3.0.0
+  checksum: 02d581edbbbb0fa292e28d96b7de36b5b62c2fa8b5a7e82638ebb33afa74284acf022d3b1e9ae10e3ffb7658fbc49163fcd5e76e7d1baaa7801c3e05a81da755
+  languageName: node
+  linkType: hard
+
+"locate-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "locate-path@npm:3.0.0"
+  dependencies:
+    p-locate: ^3.0.0
+    path-exists: ^3.0.0
+  checksum: 53db3996672f21f8b0bf2a2c645ae2c13ffdae1eeecfcd399a583bce8516c0b88dcb4222ca6efbbbeb6949df7e46860895be2c02e8d3219abd373ace3bfb4e11
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^5.0.0":
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
@@ -4293,6 +4711,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash.ismatch@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.ismatch@npm:4.4.0"
+  checksum: a393917578842705c7fc1a30fb80613d1ac42d20b67eb26a2a6004d6d61ee90b419f9eb320508ddcd608e328d91eeaa2651411727eaa9a12534ed6ccb02fc705
   languageName: node
   linkType: hard
 
@@ -4342,6 +4767,15 @@ __metadata:
   version: 7.9.0
   resolution: "lru-cache@npm:7.9.0"
   checksum: c91a293a103d11ea4f07de4122ba4f73d8203d0de51852fb612b1764296aebf623a3e11dddef1b3aefdc8d71af97d52b222dad5459dcb967713bbab9a19fed7d
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.26.1":
+  version: 0.26.1
+  resolution: "magic-string@npm:0.26.1"
+  dependencies:
+    sourcemap-codec: ^1.4.8
+  checksum: 23f21f5734346ddfbabd7b9834e3ecda3521e3e1db81166c1513b45b729489bbed1eafa8cd052c7db7fdc7c68ebc5c03bc00dd5a23697edda15dbecaf8c98397
   languageName: node
   linkType: hard
 
@@ -4534,6 +4968,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimist@npm:^1.2.5":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
+  languageName: node
+  linkType: hard
+
 "minipass-collect@npm:^1.0.2":
   version: 1.0.2
   resolution: "minipass-collect@npm:1.0.2"
@@ -4638,6 +5079,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"modify-values@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "modify-values@npm:1.0.1"
+  checksum: 8296610c608bc97b03c2cf889c6cdf4517e32fa2d836440096374c2209f6b7b3e256c209493a0b32584b9cb32d528e99d0dd19dcd9a14d2d915a312d391cc7e9
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.1.5":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -4683,6 +5131,13 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: b8ffeb1e262eff7968fc90a2b6767b04cfd9842582a9d0ece0af7049537266e7b2506dfb1d107a32f06dd849ab2aea834d5830f7f4d0e5cb7d36e1ae55d021d9
+  languageName: node
+  linkType: hard
+
+"neo-async@npm:^2.6.0":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
   languageName: node
   linkType: hard
 
@@ -4745,7 +5200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.5.0":
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -4822,6 +5277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"null-check@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "null-check@npm:1.0.0"
+  checksum: 6569fb2d74399e436eb4b05c7fdd341f22e87f3e0598a97309681073a364d6684997100cd329f2107d149663c506b2bfa47a0afdff23739ac1ba6ca5c4c6aa19
+  languageName: node
+  linkType: hard
+
 "nwsapi@npm:^2.2.0":
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
@@ -4882,7 +5344,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^2.2.0":
+"p-limit@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "p-limit@npm:1.3.0"
+  dependencies:
+    p-try: ^1.0.0
+  checksum: 281c1c0b8c82e1ac9f81acd72a2e35d402bf572e09721ce5520164e9de07d8274451378a3470707179ad13240535558f4b277f02405ad752e08c7d5b0d54fbfd
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
   dependencies:
@@ -4897,6 +5368,24 @@ __metadata:
   dependencies:
     yocto-queue: ^0.1.0
   checksum: 7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "p-locate@npm:2.0.0"
+  dependencies:
+    p-limit: ^1.1.0
+  checksum: e2dceb9b49b96d5513d90f715780f6f4972f46987dc32a0e18bc6c3fc74a1a5d73ec5f81b1398af5e58b99ea1ad03fd41e9181c01fa81b4af2833958696e3081
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-locate@npm:3.0.0"
+  dependencies:
+    p-limit: ^2.0.0
+  checksum: 83991734a9854a05fe9dbb29f707ea8a0599391f52daac32b86f08e21415e857ffa60f0e120bfe7ce0cc4faf9274a50239c7895fc0d0579d08411e513b83a4ae
   languageName: node
   linkType: hard
 
@@ -4927,6 +5416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-try@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-try@npm:1.0.0"
+  checksum: 3b5303f77eb7722144154288bfd96f799f8ff3e2b2b39330efe38db5dd359e4fb27012464cd85cb0a76e9b7edd1b443568cb3192c22e7cffc34989df0bafd605
+  languageName: node
+  linkType: hard
+
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
@@ -4940,6 +5436,16 @@ __metadata:
   dependencies:
     callsites: ^3.0.0
   checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-json@npm:4.0.0"
+  dependencies:
+    error-ex: ^1.3.1
+    json-parse-better-errors: ^1.0.1
+  checksum: 0fe227d410a61090c247e34fa210552b834613c006c2c64d9a05cfe9e89cf8b4246d1246b1a99524b53b313e9ac024438d0680f67e33eaed7e6f38db64cfe7b5
   languageName: node
   linkType: hard
 
@@ -4959,6 +5465,13 @@ __metadata:
   version: 6.0.1
   resolution: "parse5@npm:6.0.1"
   checksum: 7d569a176c5460897f7c8f3377eff640d54132b9be51ae8a8fa4979af940830b2b0c296ce75e5bd8f4041520aadde13170dbdec44889975f906098ea0002f4bd
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-exists@npm:3.0.0"
+  checksum: 96e92643aa34b4b28d0de1cd2eba52a1c5313a90c6542d03f62750d82480e20bfa62bc865d5cfc6165f5fcd5aeb0851043c40a39be5989646f223300021bae0a
   languageName: node
   linkType: hard
 
@@ -5008,6 +5521,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: ^3.0.0
+  checksum: 735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -5035,6 +5557,20 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 371cd14bbc9bdee2a6a44596dd521dd3565e223481e0b1afffdca3f1c29831850bfa7784114dc30d245d37e7d186cec035e036256b39f75d878d19498fe0df6a
+  languageName: node
+  linkType: hard
+
+"pify@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "pify@npm:2.3.0"
+  checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
+  languageName: node
+  linkType: hard
+
+"pify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pify@npm:3.0.0"
+  checksum: 6cdcbc3567d5c412450c53261a3f10991665d660961e06605decf4544a61a97a54fefe70a68d5c37080ff9d6f4cf51444c90198d1ba9f9309a6c0d6e9f5c4fde
   languageName: node
   linkType: hard
 
@@ -5124,6 +5660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -5203,6 +5746,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-pkg-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg-up@npm:3.0.0"
+  dependencies:
+    find-up: ^2.0.0
+    read-pkg: ^3.0.0
+  checksum: 16175573f2914ab9788897bcbe2a62b5728d0075e62285b3680cebe97059e2911e0134a062cf6e51ebe3e3775312bc788ac2039ed6af38ec68d2c10c6f2b30fb
+  languageName: node
+  linkType: hard
+
 "read-pkg-up@npm:^7.0.1":
   version: 7.0.1
   resolution: "read-pkg-up@npm:7.0.1"
@@ -5211,6 +5764,17 @@ __metadata:
     read-pkg: ^5.2.0
     type-fest: ^0.8.1
   checksum: e4e93ce70e5905b490ca8f883eb9e48b5d3cebc6cd4527c25a0d8f3ae2903bd4121c5ab9c5a3e217ada0141098eeb661313c86fa008524b089b8ed0b7f165e44
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg@npm:3.0.0"
+  dependencies:
+    load-json-file: ^4.0.0
+    normalize-package-data: ^2.3.2
+    path-type: ^3.0.0
+  checksum: 398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
   languageName: node
   linkType: hard
 
@@ -5226,7 +5790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -5234,6 +5798,21 @@ __metadata:
     string_decoder: ^1.1.1
     util-deprecate: ^1.0.1
   checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:~2.3.6":
+  version: 2.3.7
+  resolution: "readable-stream@npm:2.3.7"
+  dependencies:
+    core-util-is: ~1.0.0
+    inherits: ~2.0.3
+    isarray: ~1.0.0
+    process-nextick-args: ~2.0.0
+    safe-buffer: ~5.1.1
+    string_decoder: ~1.1.1
+    util-deprecate: ~1.0.1
+  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
   languageName: node
   linkType: hard
 
@@ -5390,6 +5969,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-dts@npm:^4.1.0":
+  version: 4.2.1
+  resolution: "rollup-plugin-dts@npm:4.2.1"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    magic-string: ^0.26.1
+  peerDependencies:
+    rollup: ^2.70
+    typescript: ^4.6
+  dependenciesMeta:
+    "@babel/code-frame":
+      optional: true
+  checksum: 70a593db76007159a7bbc06c26824c3275ab1d8d4d6b6e8bc06d1345f337d9d118aa8d4ec175155bc072a66b78da4242a915c3516a3270006b9758004eadeb43
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-typescript2@npm:^0.31.2":
   version: 0.31.2
   resolution: "rollup-plugin-typescript2@npm:0.31.2"
@@ -5415,6 +6010,20 @@ __metadata:
     dateformat: ^4.2.1
     lodash: ^4.17.20
   checksum: 399d1b7908ed37d927ac5103417e8a2257900c810b7198dbeffbc4fc6b363ada1088986b53882ecad1024a8a2c8c23db345a683425a57122656a6f775dd49132
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^2.63.0, rollup@npm:^2.68.0":
+  version: 2.72.1
+  resolution: "rollup@npm:2.72.1"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 3dca122129f560acc3c54dd5bd5f9470dd562d74f61c652c57b6a4355a963c0828640382ebff544f1b0e71387733a51fb963d6f761ae1f05a84f5923bbde883c
   languageName: node
   linkType: hard
 
@@ -5469,7 +6078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
@@ -5508,7 +6117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.7, semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:7.3.7, semver@npm:7.x, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -5656,6 +6265,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
+  languageName: node
+  linkType: hard
+
 "spdx-correct@npm:^3.0.0":
   version: 3.1.1
   resolution: "spdx-correct@npm:3.1.1"
@@ -5699,6 +6315,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "split@npm:1.0.1"
+  dependencies:
+    through: 2
+  checksum: 12f4554a5792c7e98bb3e22b53c63bfa5ef89aa704353e1db608a55b51f5b12afaad6e4a8ecf7843c15f273f43cdadd67b3705cc43d48a75c2cf4641d51f7e7a
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -5730,6 +6355,31 @@ __metadata:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 76b69da0f5b48a34a0f93c98ee2a96544d2c4ca2557f7eef5ddb961d3bdc33870b46f498a84a7c4f4ffb781df639840e7ebf6639164ed4da5e1aeb659615b9c7
+  languageName: node
+  linkType: hard
+
+"standard-version@npm:^9.3.2":
+  version: 9.3.2
+  resolution: "standard-version@npm:9.3.2"
+  dependencies:
+    chalk: ^2.4.2
+    conventional-changelog: 3.1.24
+    conventional-changelog-config-spec: 2.1.0
+    conventional-changelog-conventionalcommits: 4.6.1
+    conventional-recommended-bump: 6.1.0
+    detect-indent: ^6.0.0
+    detect-newline: ^3.1.0
+    dotgitignore: ^2.1.0
+    figures: ^3.1.0
+    find-up: ^5.0.0
+    fs-access: ^1.0.1
+    git-semver-tags: ^4.0.0
+    semver: ^7.1.1
+    stringify-package: ^1.0.1
+    yargs: ^16.0.0
+  bin:
+    standard-version: bin/cli.js
+  checksum: 40e1105b73e77105338a869096708e15aebf0c1104740f8cbbbb24173f55a8e7f221ff2e4cad4765c230d34094caa4e378ceb74a1ea890709c32f5fb67bd49b7
   languageName: node
   linkType: hard
 
@@ -5781,6 +6431,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: ~5.1.0
+  checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
+  languageName: node
+  linkType: hard
+
+"stringify-package@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "stringify-package@npm:1.0.1"
+  checksum: 462036085a0cf7ae073d9b88a2bbf7efb3792e3df3e1fd436851f64196eb0234c8f8ffac436357e355687d6030b7af42e98af9515929e41a6a5c8653aa62a5aa
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -5796,6 +6462,13 @@ __metadata:
   dependencies:
     ansi-regex: ^6.0.1
   checksum: 257f78fa433520e7f9897722731d78599cb3fce29ff26a20a5e12ba4957463b50a01136f37c43707f4951817a75e90820174853d6ccc240997adc5df8f966039
+  languageName: node
+  linkType: hard
+
+"strip-bom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-bom@npm:3.0.0"
+  checksum: 8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
   languageName: node
   linkType: hard
 
@@ -5943,6 +6616,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"through2@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "through2@npm:2.0.5"
+  dependencies:
+    readable-stream: ~2.3.6
+    xtend: ~4.0.1
+  checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
+  languageName: node
+  linkType: hard
+
 "through2@npm:^4.0.0":
   version: 4.0.2
   resolution: "through2@npm:4.0.2"
@@ -5952,7 +6635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:>=2.2.7 <3, through@npm:^2.3.8":
+"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.8":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
@@ -6181,7 +6864,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.4.3, typescript@npm:^4.6.3":
+"typedarray@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "typedarray@npm:0.0.6"
+  checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.4.3, typescript@npm:^4.5.4, typescript@npm:^4.6.3":
   version: 4.6.4
   resolution: "typescript@npm:4.6.4"
   bin:
@@ -6191,13 +6881,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.4.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.5.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>":
   version: 4.6.4
   resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=bda367"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
+  languageName: node
+  linkType: hard
+
+"uglify-js@npm:^3.1.4":
+  version: 3.15.4
+  resolution: "uglify-js@npm:3.15.4"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 5f673c5dd7f3b3dd15d1d26aebfe29bccbb1b896c4b5423ec70a2e8b9506c70b6fb6a53dec83df5ad65a717ec9a850adf08e0aedf9b1711eac5eb080216615fa
   languageName: node
   linkType: hard
 
@@ -6255,7 +6954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
@@ -6418,6 +7117,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 2a44b2788165d0a3de71fd517d4880a8e20ea3a82c080ce46e294f0b68b69a2e49cff5f99c600e275c698a90d12c5ea32aff06c311f0db2eb3f1201f3e7b2a04
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
@@ -6488,6 +7194,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xtend@npm:~4.0.1":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
+  languageName: node
+  linkType: hard
+
 "y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
@@ -6523,7 +7236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.2.0":
+"yargs@npm:^16.0.0, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
This PR adds the `@joshdb/serialize` package from the [/serialize](https://github.com/josh-development/serialize) repository, but converts it into a function based package rather then a class based one.

# Changes

- Add `packages/serialize` directory
- Add npm package info in `README.md`