### PR TITLE
feat(middleware): export provider package

### DIFF
--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
+export * from '@joshdb/provider';
 export * from './lib/decorators';
 export * from './lib/Middleware';
 export * from './lib/MiddlewareStore';


### PR DESCRIPTION
Makes development easier on middlewares by re-exporting `@joshdb/provider`