### PR TITLE
refactor(provider): versioning

### DIFF
--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -38,7 +38,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * The semver version of this provider.
    * @since 2.0.0
    */
-  public abstract version: JoshProvider.Semver;
+  public abstract get version(): JoshProvider.Semver;
 
   public constructor(options: JoshProvider.Options = {}) {
     this.options = options;
@@ -487,14 +487,9 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * @returns The resolved version.
    */
   protected resolveVersion(version: string): JoshProvider.Semver {
-    return version
-      .split('.')
-      .map(Number)
-      .reduce((semver, value, index) => ({ ...semver, [['major', 'minor', 'patch'][index]]: value }), {
-        major: 0,
-        minor: 0,
-        patch: 0
-      });
+    const [major, minor, patch] = version.split('.').map(Number);
+
+    return { major, minor, patch };
   }
 
   protected abstract fetchVersion(): Awaitable<JoshProvider.Semver>;

--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -65,7 +65,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
 
     this.name = name;
 
-    const version = await this.fetchVersion();
+    const version = await this.fetchVersion(context);
 
     if (version.major < this.version.major) {
       const { allowMigrations } = this.options;
@@ -492,7 +492,7 @@ export abstract class JoshProvider<StoredValue = unknown> {
     return { major, minor, patch };
   }
 
-  protected abstract fetchVersion(): Awaitable<JoshProvider.Semver>;
+  protected abstract fetchVersion(context: JoshProvider.Context): Awaitable<JoshProvider.Semver>;
 }
 
 export namespace JoshProvider {

--- a/packages/provider/tests/lib/structures/JoshProvider.test.ts
+++ b/packages/provider/tests/lib/structures/JoshProvider.test.ts
@@ -13,7 +13,9 @@ describe('JoshProvider', () => {
 
   describe('migrations', () => {
     class TestProvider<StoredValue = unknown> extends JoshProvider<StoredValue> {
-      public version = { major: 2, minor: 0, patch: 0 };
+      public get version() {
+        return { major: 2, minor: 0, patch: 0 };
+      }
 
       public migrations = [
         {


### PR DESCRIPTION
# Changes

- Add getter functionality to abstract `JoshProvider#version` property
- Add `context` parameter to abstract `JoshProvider#fetchVersion()` method

# Other Changes

- Simplify the `JoshProvider#resolveVersion()` method
- The `TestProvider#version` property in `tests/lib/structures/JoshProvider.test.ts` is now a getter