### PR TITLE
feat(JoshProviderError): add `context` and `formatMessage`

### DIFF
--- a/packages/provider/src/lib/structures/JoshProviderError.ts
+++ b/packages/provider/src/lib/structures/JoshProviderError.ts
@@ -24,14 +24,16 @@ export class JoshProviderError extends Error {
   public context: Record<PropertyKey, unknown>;
 
   public constructor(options: JoshProviderErrorOptions) {
-    const { name, message, identifier, method, context } = options;
+    const { name, identifier, method, context } = options;
 
-    super(message);
+    super(JoshProviderError.formatMessage(options));
     this.name = name ?? 'JoshError';
     this.identifier = identifier;
     this.method = method ?? null;
     this.context = context ?? {};
   }
+
+  public static formatMessage: (options: JoshProviderErrorOptions) => string | undefined = ({ message }) => message;
 }
 
 /**

--- a/packages/provider/src/lib/structures/JoshProviderError.ts
+++ b/packages/provider/src/lib/structures/JoshProviderError.ts
@@ -17,13 +17,20 @@ export class JoshProviderError extends Error {
    */
   public method: Method | null;
 
+  /**
+   * The context for this error.
+   * @since 2.0.0
+   */
+  public context: Record<PropertyKey, unknown>;
+
   public constructor(options: JoshProviderErrorOptions) {
-    const { name, message, identifier, method } = options;
+    const { name, message, identifier, method, context } = options;
 
     super(message);
     this.name = name ?? 'JoshError';
     this.identifier = identifier;
     this.method = method ?? null;
+    this.context = context ?? {};
   }
 }
 
@@ -49,6 +56,12 @@ export interface JoshProviderErrorOptions {
    * @since 2.0.0
    */
   method?: Method;
+
+  /**
+   * The context for this error.
+   * @since 2.0.0
+   */
+  context?: Record<PropertyKey, unknown>;
 
   /**
    * The message for this error.


### PR DESCRIPTION
I found while developing `@joshdb/schema` it would be useful to be able to add some extra context in the errors we create. For example, `@sapphire/shapeshift` throws an error when validating data which we catch and then return our own error. In this case it would be useful to provide the error thrown originally to the end-user.