### PR TITLE
feat(Middleware)!: rename and move `Middleware.Identifiers` to `MiddlewareIdentifiers`

### DIFF
--- a/packages/middleware/src/lib/Middleware.ts
+++ b/packages/middleware/src/lib/Middleware.ts
@@ -308,10 +308,10 @@ export namespace Middleware {
      */
     conditions: Conditions;
   }
+}
 
-  export enum Identifiers {
-    NameNotFound = 'nameNotFound',
+export enum MiddlewareIdentifiers {
+  NameNotFound = 'nameNotFound',
 
-    StoreNotFound = 'storeNotFound'
-  }
+  StoreNotFound = 'storeNotFound'
 }


### PR DESCRIPTION
Oversight for creating `Middleware` which may need their own `Identifiers` enum inside a namespace of their `Middleware`