### PR TITLE
refactor(Payload): remove `error` property and add `errors` property

### DIFF
--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -1,7 +1,7 @@
 import type { Awaitable } from '@sapphire/utilities';
 import { resolveCommonIdentifier } from '../functions';
 import type { Method, Payloads } from '../types';
-import { JoshProviderError, JoshProviderErrorOptions } from './JoshProviderError';
+import { JoshProviderError } from './JoshProviderError';
 
 /**
  * The base provider class. Extend this class to create your own provider.
@@ -446,8 +446,15 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * @param options The options for the error.
    * @returns The error.
    */
-  protected error(options: string | JoshProviderErrorOptions, metadata: Record<string, unknown> = {}): JoshProviderError {
-    if (typeof options === 'string') return new JoshProviderError({ identifier: options, message: this.resolveIdentifier(options, metadata) });
+  protected error(options: string | JoshProviderError.Options, metadata: Record<string, unknown> = {}): JoshProviderError {
+    if (typeof options === 'string') {
+      return new JoshProviderError({
+        identifier: options,
+        origin: { type: JoshProviderError.OriginType.Provider, name: this.constructor.name.replace(/Provider/, '') },
+        message: this.resolveIdentifier(options, metadata)
+      });
+    }
+
     if ('message' in options) return new JoshProviderError(options);
 
     return new JoshProviderError({ ...options, name: options.name ?? `${this.constructor.name}Error` });

--- a/packages/provider/src/lib/structures/JoshProviderError.ts
+++ b/packages/provider/src/lib/structures/JoshProviderError.ts
@@ -23,7 +23,7 @@ export class JoshProviderError extends Error {
    */
   public context: Record<PropertyKey, unknown>;
 
-  public constructor(options: JoshProviderErrorOptions) {
+  public constructor(options: JoshProviderError.Options) {
     const { name, identifier, method, context } = options;
 
     super(JoshProviderError.formatMessage(options));
@@ -33,41 +33,69 @@ export class JoshProviderError extends Error {
     this.context = context ?? {};
   }
 
-  public static formatMessage: (options: JoshProviderErrorOptions) => string | undefined = ({ message }) => message;
+  public static formatMessage: (options: JoshProviderError.Options) => string | undefined = ({ message }) => message;
 }
 
-/**
- * The options for `JoshError`
- * @since 1.0.0
- */
-export interface JoshProviderErrorOptions {
+export namespace JoshProviderError {
   /**
-   * The name for this error.
+   * The options for `JoshError`
    * @since 1.0.0
    */
-  name?: string;
+  export interface Options {
+    /**
+     * The name for this error.
+     * @since 1.0.0
+     */
+    name?: string;
 
-  /**
-   * The identifier for this error.
-   * @since 1.0.0
-   */
-  identifier: string;
+    /**
+     * The identifier for this error.
+     * @since 1.0.0
+     */
+    identifier: string;
 
-  /**
-   * The method this error applies to.
-   * @since 1.0.0
-   */
-  method?: Method;
+    /**
+     * The method this error applies to.
+     * @since 1.0.0
+     */
+    method?: Method;
 
-  /**
-   * The context for this error.
-   * @since 1.0.0
-   */
-  context?: Record<PropertyKey, unknown>;
+    /**
+     * The origin of this error.
+     * @since 1.0.0
+     */
+    origin: Origin;
 
-  /**
-   * The message for this error.
-   * @since 1.0.0
-   */
-  message?: string;
+    /**
+     * The context for this error.
+     * @since 1.0.0
+     */
+    context?: Record<PropertyKey, unknown>;
+
+    /**
+     * The message for this error.
+     * @since 1.0.0
+     */
+    message?: string;
+  }
+
+  export interface Origin {
+    /**
+     * The origin type for this origin.
+     * @since 1.0.0
+     */
+    type: OriginType;
+
+    /**
+     * The origin name for this origin.
+     * @since 1.0.0
+     */
+    name: string;
+  }
+
+  export enum OriginType {
+    Provider = 'provider',
+
+    Middleware = 'middleware'
+  }
 }

--- a/packages/provider/src/lib/types/Payload.ts
+++ b/packages/provider/src/lib/types/Payload.ts
@@ -27,10 +27,10 @@ export interface Payload {
   trigger?: Trigger;
 
   /**
-   * The error from this payload.
+   * The errors that occurred during payload execution.
    * @since 1.0.0
    */
-  error?: JoshProviderError;
+  errors: JoshProviderError[];
 }
 
 export namespace Payload {

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -30,30 +30,33 @@ export function runProviderTest<
         });
 
         beforeEach(async () => {
-          await provider[Method.Clear]({ method: Method.Clear });
+          await provider[Method.Clear]({ method: Method.Clear, errors: [] });
         });
 
         afterAll(async () => {
-          await provider[Method.Clear]({ method: Method.Clear });
+          await provider[Method.Clear]({ method: Method.Clear, errors: [] });
           if (typeof cleanup === 'function') await cleanup(provider as CleanupProvider);
         });
 
         describe(Method.AutoKey, () => {
           test('GIVEN ... THEN returns payload w/ generated key as data AND increments autoKeyCount', async () => {
-            const payload = await provider[Method.AutoKey]({ method: Method.AutoKey });
+            const payload = await provider[Method.AutoKey]({ method: Method.AutoKey, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.AutoKey);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(typeof data).toBe('string');
           });
 
           test('each value of autoKey should be unique', async () => {
-            const arr = await Promise.all([...Array(10)].map(async () => (await provider[Method.AutoKey]({ method: Method.AutoKey })).data));
+            const arr = await Promise.all(
+              [...Array(10)].map(async () => (await provider[Method.AutoKey]({ method: Method.AutoKey, errors: [] })).data)
+            );
+
             const isUnique = new Set(arr).size === arr.length;
 
             expect(isUnique).toBe(true);
@@ -62,43 +65,43 @@ export function runProviderTest<
 
         describe(Method.Clear, () => {
           test('GIVEN provider w/o data THEN provider data cleared', async () => {
-            const sizeBefore = await provider[Method.Size]({ method: Method.Size });
+            const sizeBefore = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeBefore.data).toBe(0);
 
-            const payload = await provider[Method.Clear]({ method: Method.Clear });
+            const payload = await provider[Method.Clear]({ method: Method.Clear, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error } = payload;
+            const { method, trigger, errors } = payload;
 
             expect(method).toBe(Method.Clear);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
 
-            const sizeAfter = await provider[Method.Size]({ method: Method.Size });
+            const sizeAfter = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeAfter.data).toBe(0);
           });
 
           test('GIVEN provider w/ data THEN provider data cleared', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const sizeBefore = await provider[Method.Size]({ method: Method.Size });
+            const sizeBefore = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeBefore.data).toBe(1);
 
-            const payload = await provider[Method.Clear]({ method: Method.Clear });
+            const payload = await provider[Method.Clear]({ method: Method.Clear, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error } = payload;
+            const { method, trigger, errors } = payload;
 
             expect(method).toBe(Method.Clear);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
 
-            const sizeAfter = await provider[Method.Size]({ method: Method.Size });
+            const sizeAfter = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeAfter.data).toBe(0);
           });
@@ -106,105 +109,105 @@ export function runProviderTest<
 
         describe(Method.Dec, () => {
           test('GIVEN provider w/o data at key THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: [] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual([]);
           });
 
           test('GIVEN provider w/o data at path THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
           });
 
           test('GIVEN provider w/ invalid type at key THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: [] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual([]);
           });
 
           test('GIVEN provider w/ invalid type at path THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
           });
 
           test('GIVEN provider w/ number at key THEN decremented number at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 1 });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 1 });
 
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: [] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(get.data).toEqual(0);
           });
 
           test('GIVEN provider w/ number at path THEN decremented number at path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 1 });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 1 });
 
-            const payload = await provider[Method.Dec]({ method: Method.Dec, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Dec]({ method: Method.Dec, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Dec);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: ['path'] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: ['path'] });
 
             expect(get.data).toEqual(0);
           });
@@ -212,67 +215,67 @@ export function runProviderTest<
 
         describe(Method.Delete, () => {
           test('GIVEN provider w/ value at key THEN deletes value at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasBefore.data).toBe(true);
 
-            const payload = await provider[Method.Delete]({ method: Method.Delete, key: 'key', path: [] });
+            const payload = await provider[Method.Delete]({ method: Method.Delete, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error } = payload;
+            const { method, trigger, errors } = payload;
 
             expect(method).toBe(Method.Delete);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
 
-            const hasAfter = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasAfter = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasAfter.data).toBe(false);
           });
 
           test('GIVEN provider w/ value at path THEN deletes value at path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(hasBefore.data).toBe(true);
 
-            const payload = await provider[Method.Delete]({ method: Method.Delete, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Delete]({ method: Method.Delete, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error } = payload;
+            const { method, trigger, errors } = payload;
 
             expect(method).toBe(Method.Delete);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
 
-            const hasAfter = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const hasAfter = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(hasAfter.data).toBe(false);
           });
 
           test('GIVEN provider w/ value at nested path THEN deletes value at nested path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path', 'nested'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path', 'nested'], value: 'value' });
 
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path', 'nested'] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path', 'nested'] });
 
             expect(hasBefore.data).toBe(true);
 
-            const payload = await provider[Method.Delete]({ method: Method.Delete, key: 'key', path: ['path', 'nested'] });
+            const payload = await provider[Method.Delete]({ method: Method.Delete, errors: [], key: 'key', path: ['path', 'nested'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error } = payload;
+            const { method, trigger, errors } = payload;
 
             expect(method).toBe(Method.Delete);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
 
-            const hasAfter = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path', 'nested'] });
+            const hasAfter = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path', 'nested'] });
 
             expect(hasAfter.data).toBe(false);
           });
@@ -280,40 +283,40 @@ export function runProviderTest<
 
         describe(Method.Ensure, () => {
           test('GIVEN provider w/o data at key THEN returns payload w/ data as defaultValue AND sets default value at key', async () => {
-            const sizeBefore = await provider[Method.Size]({ method: Method.Size });
+            const sizeBefore = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeBefore.data).toBe(0);
 
-            const payload = await provider[Method.Ensure]({ method: Method.Ensure, key: 'key', defaultValue: 'defaultValue' });
+            const payload = await provider[Method.Ensure]({ method: Method.Ensure, errors: [], key: 'key', defaultValue: 'defaultValue' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, defaultValue, data } = payload;
+            const { method, trigger, errors, key, defaultValue, data } = payload;
 
             expect(method).toBe(Method.Ensure);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(defaultValue).toBe('defaultValue');
             expect(data).toBe('defaultValue');
 
-            const sizeAfter = await provider[Method.Size]({ method: Method.Size });
+            const sizeAfter = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(sizeAfter.data).toBe(1);
           });
 
           test('GIVEN provider w/ value at key THEN returns payload w/ data as value at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Ensure]({ method: Method.Ensure, key: 'key', defaultValue: 'defaultValue' });
+            const payload = await provider[Method.Ensure]({ method: Method.Ensure, errors: [], key: 'key', defaultValue: 'defaultValue' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, defaultValue, data } = payload;
+            const { method, trigger, errors, key, defaultValue, data } = payload;
 
             expect(method).toBe(Method.Ensure);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(defaultValue).toBe('defaultValue');
             expect(data).toBe('value');
@@ -322,30 +325,30 @@ export function runProviderTest<
 
         describe(Method.Entries, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from getAll', async () => {
-            const payload = await provider.entries({ method: Method.Entries });
+            const payload = await provider.entries({ method: Method.Entries, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Entries);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual({});
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data from getAll', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider.entries({ method: Method.Entries });
+            const payload = await provider.entries({ method: Method.Entries, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Entries);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual({ key: 'value' });
           });
         });
@@ -353,15 +356,20 @@ export function runProviderTest<
         describe(Method.Every, () => {
           describe(Payload.Type.Hook, () => {
             test('GIVEN provider w/o data THEN returns payload(true)', async () => {
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Every]({
+                method: Method.Every,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toBe(true);
             });
@@ -369,6 +377,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload(true)', async () => {
               await provider[Method.SetMany]({
                 method: Method.SetMany,
+                errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
                   { key: 'secondKey', path: [], value: 'value' }
@@ -376,15 +385,20 @@ export function runProviderTest<
                 overwrite: true
               });
 
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Every]({
+                method: Method.Every,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toBe(true);
             });
@@ -392,15 +406,21 @@ export function runProviderTest<
 
           describe(Payload.Type.Value, () => {
             test('GIVEN provider w/o data THEN returns payload(true)', async () => {
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Every]({
+                method: Method.Every,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toBe(true);
@@ -409,6 +429,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload(true)', async () => {
               await provider[Method.SetMany]({
                 method: Method.SetMany,
+                errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
                   { key: 'secondKey', path: [], value: 'value' }
@@ -416,30 +437,36 @@ export function runProviderTest<
                 overwrite: true
               });
 
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Every]({
+                method: Method.Every,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toBe(true);
             });
 
             test('GIVEN provider w/o data w/o path THEN returns payload(true)', async () => {
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Value, path: [], value: 'value' });
+              const payload = await provider[Method.Every]({ method: Method.Every, errors: [], type: Payload.Type.Value, path: [], value: 'value' });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(value).toBe('value');
               expect(data).toBe(true);
@@ -448,6 +475,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data w/o path THEN returns payload(true)', async () => {
               await provider[Method.SetMany]({
                 method: Method.SetMany,
+                errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
                   { key: 'secondKey', path: [], value: 'value' }
@@ -455,15 +483,15 @@ export function runProviderTest<
                 overwrite: true
               });
 
-              const payload = await provider[Method.Every]({ method: Method.Every, type: Payload.Type.Value, path: [], value: 'value' });
+              const payload = await provider[Method.Every]({ method: Method.Every, errors: [], type: Payload.Type.Value, path: [], value: 'value' });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Every);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(value).toBe('value');
               expect(data).toBe(true);
@@ -474,31 +502,41 @@ export function runProviderTest<
         describe(Method.Filter, () => {
           describe(Payload.Type.Hook, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from filter', async () => {
-              const payload = await provider[Method.Filter]({ method: Method.Filter, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Filter]({
+                method: Method.Filter,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Filter);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual({});
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data from filter', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Filter]({ method: Method.Filter, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Filter]({
+                method: Method.Filter,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Filter);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual({ key: 'value' });
             });
@@ -506,32 +544,44 @@ export function runProviderTest<
 
           describe(Payload.Type.Value, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from filter', async () => {
-              const payload = await provider[Method.Filter]({ method: Method.Filter, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Filter]({
+                method: Method.Filter,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Filter);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toEqual({});
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data from filter', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-              const payload = await provider[Method.Filter]({ method: Method.Filter, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Filter]({
+                method: Method.Filter,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Filter);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toEqual({ key: { path: 'value' } });
@@ -542,32 +592,42 @@ export function runProviderTest<
         describe(Method.Find, () => {
           describe(Payload.Type.Hook, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from find', async () => {
-              const payload = await provider[Method.Find]({ method: Method.Find, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Find]({
+                method: Method.Find,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
               expect(method).toBe(Method.Find);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual([null, null]);
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data from find', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Find]({ method: Method.Find, type: Payload.Type.Hook, hook: (value) => value === 'value' });
+              const payload = await provider[Method.Find]({
+                method: Method.Find,
+                errors: [],
+                type: Payload.Type.Hook,
+                hook: (value) => value === 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Find);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual(['key', 'value']);
             });
@@ -575,32 +635,44 @@ export function runProviderTest<
 
           describe(Payload.Type.Value, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from find', async () => {
-              const payload = await provider[Method.Find]({ method: Method.Find, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Find]({
+                method: Method.Find,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Find);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toEqual([null, null]);
             });
 
             test('GIVEN provider w/ data THEN returns payload w/o data from find', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-              const payload = await provider[Method.Find]({ method: Method.Find, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Find]({
+                method: Method.Find,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Find);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toEqual(['key', { path: 'value' }]);
@@ -610,49 +682,49 @@ export function runProviderTest<
 
         describe(Method.Get, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from get', async () => {
-            const payload = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const payload = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Get);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(data).toBeUndefined();
           });
 
           test('GIVEN provider w/ value at key THEN returns payload w/ data from get at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const payload = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Get);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(data).toBe('value');
           });
 
           test('GIVEN provider w/ value at path THEN returns payload w/ data from get at path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const payload = await provider[Method.Get]({ method: Method.Get, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Get);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(data).toBe('value');
@@ -661,33 +733,33 @@ export function runProviderTest<
 
         describe(Method.GetMany, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from getMany', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: null });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: null });
 
-            const payload = await provider[Method.GetMany]({ method: Method.GetMany, keys: ['key'] });
+            const payload = await provider[Method.GetMany]({ method: Method.GetMany, errors: [], keys: ['key'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, keys, data } = payload;
+            const { method, trigger, errors, keys, data } = payload;
 
             expect(method).toBe(Method.GetMany);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(keys).toEqual(['key']);
             expect(data).toEqual({ key: null });
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data from getMany', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.GetMany]({ method: Method.GetMany, keys: ['key'] });
+            const payload = await provider[Method.GetMany]({ method: Method.GetMany, errors: [], keys: ['key'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, keys, data } = payload;
+            const { method, trigger, errors, keys, data } = payload;
 
             expect(method).toBe(Method.GetMany);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(keys).toEqual(['key']);
             expect(data).toEqual({ key: 'value' });
           });
@@ -695,66 +767,66 @@ export function runProviderTest<
 
         describe(Method.Has, () => {
           test('GIVEN provider w/o data at key THEN returns payload(false)', async () => {
-            const payload = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const payload = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Has);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(data).toBe(false);
           });
 
           test('GIVEN provider w/o data at path THEN returns payload(false)', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Has);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(data).toBe(false);
           });
 
           test('GIVEN provider w/ data at key THEN returns payload(true)', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const payload = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Has);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(data).toBe(true);
           });
 
           test('GIVEN provider w/ data at path THEN returns payload(true)', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const payload = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, data } = payload;
+            const { method, trigger, errors, key, path, data } = payload;
 
             expect(method).toBe(Method.Has);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(data).toBe(true);
@@ -763,105 +835,105 @@ export function runProviderTest<
 
         describe(Method.Inc, () => {
           test('GIVEN provider w/o data at key THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: [] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual([]);
           });
 
           test('GIVEN provider w/o data at path THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
           });
 
           test('GIVEN provider w/ invalid type at key THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: [] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual([]);
           });
 
           test('GIVEN provider w/ invalid type at path THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
           });
 
           test('GIVEN provider w/ number at key THEN incremented number at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 0 });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 0 });
 
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: [] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(get.data).toEqual(2);
           });
 
           test('GIVEN provider w/ number at path THEN incremented number at key and path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 0 });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 0 });
 
-            const payload = await provider[Method.Inc]({ method: Method.Inc, key: 'key', path: ['path'] });
+            const payload = await provider[Method.Inc]({ method: Method.Inc, errors: [], key: 'key', path: ['path'] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path } = payload;
+            const { method, trigger, errors, key, path } = payload;
 
             expect(method).toBe(Method.Inc);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: ['path'] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: ['path'] });
 
             expect(get.data).toEqual(2);
           });
@@ -869,30 +941,30 @@ export function runProviderTest<
 
         describe(Method.Keys, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from keys', async () => {
-            const payload = await provider[Method.Keys]({ method: Method.Keys });
+            const payload = await provider[Method.Keys]({ method: Method.Keys, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Keys);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual([]);
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data from keys', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Keys]({ method: Method.Keys });
+            const payload = await provider[Method.Keys]({ method: Method.Keys, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Keys);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual(['key']);
           });
         });
@@ -900,31 +972,31 @@ export function runProviderTest<
         describe(Method.Map, () => {
           describe(Payload.Type.Hook, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from map', async () => {
-              const payload = await provider[Method.Map]({ method: Method.Map, type: Payload.Type.Hook, hook: (value) => value });
+              const payload = await provider[Method.Map]({ method: Method.Map, errors: [], type: Payload.Type.Hook, hook: (value) => value });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Map);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual([]);
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data from map', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Map]({ method: Method.Map, type: Payload.Type.Hook, hook: (value) => value });
+              const payload = await provider[Method.Map]({ method: Method.Map, errors: [], type: Payload.Type.Hook, hook: (value) => value });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Map);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toEqual(['value']);
             });
@@ -932,47 +1004,47 @@ export function runProviderTest<
 
           describe(Payload.Type.Path, () => {
             test('GIVEN provider w/o data THEN returns payload w/o data from map', async () => {
-              const payload = await provider[Method.Map]({ method: Method.Map, type: Payload.Type.Path, path: [] });
+              const payload = await provider[Method.Map]({ method: Method.Map, errors: [], type: Payload.Type.Path, path: [] });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, data } = payload;
+              const { method, trigger, errors, path, data } = payload;
 
               expect(method).toBe(Method.Map);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(data).toEqual([]);
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data from map', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Map]({ method: Method.Map, type: Payload.Type.Path, path: [] });
+              const payload = await provider[Method.Map]({ method: Method.Map, errors: [], type: Payload.Type.Path, path: [] });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, data } = payload;
+              const { method, trigger, errors, path, data } = payload;
 
               expect(method).toBe(Method.Map);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(data).toEqual(['value']);
             });
 
             test('GIVEN provider w/ data at path THEN returns payload w/ data from map', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-              const payload = await provider[Method.Map]({ method: Method.Map, type: Payload.Type.Path, path: ['path'] });
+              const payload = await provider[Method.Map]({ method: Method.Map, errors: [], type: Payload.Type.Path, path: ['path'] });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, data } = payload;
+              const { method, trigger, errors, path, data } = payload;
 
               expect(method).toBe(Method.Map);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(data).toEqual(['value']);
             });
@@ -983,6 +1055,7 @@ export function runProviderTest<
           test('GIVEN provider w/o data THEN returns payload w/ error', async () => {
             const payload = await provider[Method.Math]({
               method: Method.Math,
+              errors: [],
               key: 'key',
               path: [],
               operator: MathOperator.Addition,
@@ -991,12 +1064,12 @@ export function runProviderTest<
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, operator, operand } = payload;
+            const { method, trigger, errors, key, path, operator, operand } = payload;
 
             expect(method).toBe(Method.Math);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(operator).toBe(MathOperator.Addition);
@@ -1004,10 +1077,11 @@ export function runProviderTest<
           });
 
           test('GIVEN provider w/o data at path THEN returns payload w/ error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 0 });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 0 });
 
             const payload = await provider[Method.Math]({
               method: Method.Math,
+              errors: [],
               key: 'key',
               path: ['path'],
               operator: MathOperator.Addition,
@@ -1016,12 +1090,12 @@ export function runProviderTest<
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, operator, operand } = payload;
+            const { method, trigger, errors, key, path, operator, operand } = payload;
 
             expect(method).toBe(Method.Math);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(operator).toBe(MathOperator.Addition);
@@ -1029,10 +1103,11 @@ export function runProviderTest<
           });
 
           test('GIVEN provider w/ invalid type at key THEN returns payload w/ error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
             const payload = await provider[Method.Math]({
               method: Method.Math,
+              errors: [],
               key: 'key',
               path: [],
               operator: MathOperator.Addition,
@@ -1041,12 +1116,12 @@ export function runProviderTest<
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, operator, operand } = payload;
+            const { method, trigger, errors, key, path, operator, operand } = payload;
 
             expect(method).toBe(Method.Math);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(operator).toBe(MathOperator.Addition);
@@ -1054,10 +1129,11 @@ export function runProviderTest<
           });
 
           test('GIVEN provider w/ invalid type at path THEN returns payload w/ error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             const payload = await provider[Method.Math]({
               method: Method.Math,
+              errors: [],
               key: 'key',
               path: ['path'],
               operator: MathOperator.Addition,
@@ -1066,12 +1142,12 @@ export function runProviderTest<
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, operator, operand } = payload;
+            const { method, trigger, errors, key, path, operator, operand } = payload;
 
             expect(method).toBe(Method.Math);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(operator).toBe(MathOperator.Addition);
@@ -1084,17 +1160,18 @@ export function runProviderTest<
             test('GIVEN provider w/o data THEN returns payload w/o data', async () => {
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Hook,
                 hook: (value) => value === 'value'
               });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, hook, data } = payload;
+              const { method, trigger, errors, type, hook, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Hook);
               expect(typeof hook).toBe('function');
               expect(data?.truthy).toEqual({});
@@ -1102,21 +1179,22 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Hook,
                 hook: (value) => value === 'value'
               });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, hook, data } = payload;
+              const { method, trigger, errors, type, hook, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Hook);
               expect(typeof hook).toBe('function');
               expect(data?.truthy).toEqual({ key: 'value' });
@@ -1124,21 +1202,22 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Hook,
                 hook: (value) => value !== 'value'
               });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, hook, data } = payload;
+              const { method, trigger, errors, type, hook, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Hook);
               expect(typeof hook).toBe('function');
               expect(data?.truthy).toEqual({});
@@ -1150,6 +1229,7 @@ export function runProviderTest<
             test('GIVEN provider w/o data THEN returns payload w/o data', async () => {
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Value,
                 path: [],
                 value: 'value'
@@ -1157,11 +1237,11 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, path, value, data } = payload;
+              const { method, trigger, errors, type, path, value, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Value);
               expect(path).toEqual([]);
               expect(value).toBe('value');
@@ -1170,10 +1250,11 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Value,
                 path: [],
                 value: 'value'
@@ -1181,11 +1262,11 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, path, value, data } = payload;
+              const { method, trigger, errors, type, path, value, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Value);
               expect(path).toEqual([]);
               expect(value).toBe('value');
@@ -1194,10 +1275,11 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ data THEN returns payload w/ data', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Partition]({
                 method: Method.Partition,
+                errors: [],
                 type: Payload.Type.Value,
                 path: [],
                 value: 'anotherValue'
@@ -1205,11 +1287,11 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, path, value, data } = payload;
+              const { method, trigger, errors, type, path, value, data } = payload;
 
               expect(method).toBe(Method.Partition);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Value);
               expect(path).toEqual([]);
               expect(value).toBe('anotherValue');
@@ -1221,113 +1303,113 @@ export function runProviderTest<
 
         describe(Method.Push, () => {
           test('GIVEN provider w/o data THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: [], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: [], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(value).toBe('value');
           });
 
           test('GIVEN provider w/o data at path THEN returns payload w/ missing data error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: {} });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: {} });
 
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: ['path'], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(value).toBe('value');
           });
 
           test('GIVEN provider w/ invalid type at key THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: [], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: [], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(value).toBe('value');
           });
 
           test('GIVEN provider w/ invalid type at path THEN returns payload w/ invalid type error', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: ['path'], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(value).toBe('value');
           });
 
           test('GIVEN provider w/ array at key THEN returns payload AND pushes value to array at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: [] });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: [] });
 
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: [], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: [], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(value).toBe('value');
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(get.data).toEqual(['value']);
           });
 
           test('GIVEN provider w/ array at path THEN returns payload AND pushes value to array at path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: [] });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: [] });
 
-            const payload = await provider[Method.Push]({ method: Method.Push, key: 'key', path: ['path'], value: 'value' });
+            const payload = await provider[Method.Push]({ method: Method.Push, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Push);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(value).toBe('value');
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: ['path'] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: ['path'] });
 
             expect(get.data).toEqual(['value']);
           });
@@ -1335,60 +1417,60 @@ export function runProviderTest<
 
         describe(Method.Random, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from random', async () => {
-            const payload = await provider[Method.Random]({ method: Method.Random, count: 1, duplicates: false });
+            const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Random);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toBeUndefined();
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Random]({ method: Method.Random, count: 1, duplicates: false });
+            const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Random);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual(['value']);
           });
         });
 
         describe(Method.RandomKey, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data from randomKey', async () => {
-            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, count: 1, duplicates: false });
+            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.RandomKey);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toBeUndefined();
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, count: 1, duplicates: false });
+            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.RandomKey);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual(['key']);
           });
         });
@@ -1398,6 +1480,7 @@ export function runProviderTest<
             test('GIVEN provider w/o data at key THEN returns payload w/ missing data error', async () => {
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
@@ -1406,12 +1489,12 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, hook } = payload;
+              const { method, trigger, errors, type, key, path, hook } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeInstanceOf(Error);
-              expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
               expect(type).toBe(Payload.Type.Hook);
               expect(key).toBe('key');
               expect(path).toEqual([]);
@@ -1419,10 +1502,11 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ invalid type at key THEN returns payload w/ invalid type error', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
@@ -1431,12 +1515,12 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, hook } = payload;
+              const { method, trigger, errors, type, key, path, hook } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeInstanceOf(Error);
-              expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
               expect(type).toBe(Payload.Type.Hook);
               expect(key).toBe('key');
               expect(path).toEqual([]);
@@ -1444,14 +1528,15 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ array at key THEN returns payload AND removes value from array at key', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: ['value'] });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: ['value'] });
 
-              const getBefore = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+              const getBefore = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
               expect(getBefore.data).toEqual(['value']);
 
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
@@ -1460,17 +1545,17 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, hook } = payload;
+              const { method, trigger, errors, type, key, path, hook } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Hook);
               expect(key).toBe('key');
               expect(path).toEqual([]);
               expect(typeof hook).toBe('function');
 
-              const getAfter = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+              const getAfter = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
               expect(getAfter.data).toEqual([]);
             });
@@ -1480,6 +1565,7 @@ export function runProviderTest<
             test('GIVEN provider w/o data at key THEN returns payload w/ missing data error', async () => {
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
@@ -1488,12 +1574,12 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, value } = payload;
+              const { method, trigger, errors, type, key, path, value } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeInstanceOf(Error);
-              expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
               expect(type).toBe(Payload.Type.Value);
               expect(key).toBe('key');
               expect(path).toEqual([]);
@@ -1501,10 +1587,11 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ invalid type at key THEN returns payload w/ invalid type error', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
@@ -1513,12 +1600,12 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, value } = payload;
+              const { method, trigger, errors, type, key, path, value } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeInstanceOf(Error);
-              expect(error?.identifier).toBe(CommonIdentifiers.InvalidDataType);
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidDataType);
               expect(type).toBe(Payload.Type.Value);
               expect(key).toBe('key');
               expect(path).toEqual([]);
@@ -1526,14 +1613,15 @@ export function runProviderTest<
             });
 
             test('GIVEN provider w/ array at key THEN returns payload AND removes value from array at key', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: ['value'] });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: ['value'] });
 
-              const getBefore = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+              const getBefore = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
               expect(getBefore.data).toEqual(['value']);
 
               const payload = await provider[Method.Remove]({
                 method: Method.Remove,
+                errors: [],
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
@@ -1542,17 +1630,17 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, type, key, path, value } = payload;
+              const { method, trigger, errors, type, key, path, value } = payload;
 
               expect(method).toBe(Method.Remove);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(type).toBe(Payload.Type.Value);
               expect(key).toBe('key');
               expect(path).toEqual([]);
               expect(value).toBe('value');
 
-              const getAfter = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+              const getAfter = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
               expect(getAfter.data).toEqual([]);
             });
@@ -1561,47 +1649,47 @@ export function runProviderTest<
 
         describe(Method.Set, () => {
           test('GIVEN provider w/o data THEN returns payload AND sets value at key', async () => {
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasBefore.data).toBe(false);
 
-            const payload = await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            const payload = await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Set);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual([]);
             expect(value).toBe('value');
 
-            const hasAfter = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasAfter = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasAfter.data).toBe(true);
           });
 
           test('GIVEN provider w/o data THEN returns payload AND sets value at key and path', async () => {
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(hasBefore.data).toBe(false);
 
-            const payload = await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            const payload = await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, path, value } = payload;
+            const { method, trigger, errors, key, path, value } = payload;
 
             expect(method).toBe(Method.Set);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(path).toEqual(['path']);
             expect(value).toBe('value');
 
-            const hasAfter = await provider[Method.Has]({ method: Method.Has, key: 'key', path: ['path'] });
+            const hasAfter = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: ['path'] });
 
             expect(hasAfter.data).toBe(true);
           });
@@ -1609,49 +1697,51 @@ export function runProviderTest<
 
         describe(Method.SetMany, () => {
           test('GIVEN provider w/o data THEN returns payload AND sets value at key', async () => {
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasBefore.data).toBe(false);
 
             const payload = await provider[Method.SetMany]({
               method: Method.SetMany,
+              errors: [],
               entries: [{ key: 'key', path: [], value: 'value' }],
               overwrite: true
             });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, entries } = payload;
+            const { method, trigger, errors, entries } = payload;
 
             expect(method).toBe(Method.SetMany);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(entries).toEqual([{ key: 'key', path: [], value: 'value' }]);
           });
 
           test('GIVEN provider w/ data THEN returns payload AND does not set value at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const hasBefore = await provider[Method.Has]({ method: Method.Has, key: 'key', path: [] });
+            const hasBefore = await provider[Method.Has]({ method: Method.Has, errors: [], key: 'key', path: [] });
 
             expect(hasBefore.data).toBe(true);
 
             const payload = await provider[Method.SetMany]({
               method: Method.SetMany,
+              errors: [],
               entries: [{ key: 'key', path: [], value: 'anotherValue' }],
               overwrite: false
             });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, entries } = payload;
+            const { method, trigger, errors, entries } = payload;
 
             expect(method).toBe(Method.SetMany);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(entries).toEqual([{ key: 'key', path: [], value: 'anotherValue' }]);
 
-            const getAfter = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const getAfter = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(getAfter.data).toBe('value');
           });
@@ -1659,30 +1749,30 @@ export function runProviderTest<
 
         describe(Method.Size, () => {
           test('GIVEN provider w/o data THEN returns payload(0)', async () => {
-            const payload = await provider[Method.Size]({ method: Method.Size });
+            const payload = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Size);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toBe(0);
           });
 
           test('GIVEN provider w/ data THEN returns payload(1)', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Size]({ method: Method.Size });
+            const payload = await provider[Method.Size]({ method: Method.Size, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Size);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toBe(1);
           });
         });
@@ -1692,37 +1782,39 @@ export function runProviderTest<
             test('GIVEN provider w/o data THEN returns payload(false)', async () => {
               const payload = await provider[Method.Some]({
                 method: Method.Some,
+                errors: [],
                 type: Payload.Type.Hook,
                 hook: (value) => value === 'value'
               });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toBe(false);
             });
 
             test('GIVEN provider w/ data THEN returns payload(true)', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Some]({
                 method: Method.Some,
+                errors: [],
                 type: Payload.Type.Hook,
                 hook: (value) => value === 'value'
               });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, hook, data } = payload;
+              const { method, trigger, errors, hook, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(typeof hook).toBe('function');
               expect(data).toBe(true);
             });
@@ -1730,32 +1822,44 @@ export function runProviderTest<
 
           describe(Payload.Type.Value, () => {
             test('GIVEN provider w/o data THEN returns payload(false)', async () => {
-              const payload = await provider[Method.Some]({ method: Method.Some, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Some]({
+                method: Method.Some,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toBe(false);
             });
 
             test('GIVEN provider w/ data THEN returns payload(true)', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
-              const payload = await provider[Method.Some]({ method: Method.Some, type: Payload.Type.Value, path: ['path'], value: 'value' });
+              const payload = await provider[Method.Some]({
+                method: Method.Some,
+                errors: [],
+                type: Payload.Type.Value,
+                path: ['path'],
+                value: 'value'
+              });
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual(['path']);
               expect(value).toBe('value');
               expect(data).toBe(true);
@@ -1764,6 +1868,7 @@ export function runProviderTest<
             test('GIVEN provider w/o data w/o path THEN returns payload(false)', async () => {
               const payload = await provider[Method.Some]({
                 method: Method.Some,
+                errors: [],
                 type: Payload.Type.Value,
                 path: [],
                 value: 'value'
@@ -1771,21 +1876,22 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(value).toBe('value');
               expect(data).toBe(false);
             });
 
             test('GIVEN provider w/ data w/o path THEN returns payload(true)', async () => {
-              await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
               const payload = await provider[Method.Some]({
                 method: Method.Some,
+                errors: [],
                 type: Payload.Type.Value,
                 path: [],
                 value: 'value'
@@ -1793,11 +1899,11 @@ export function runProviderTest<
 
               expect(typeof payload).toBe('object');
 
-              const { method, trigger, error, path, value, data } = payload;
+              const { method, trigger, errors, path, value, data } = payload;
 
               expect(method).toBe(Method.Some);
               expect(trigger).toBeUndefined();
-              expect(error).toBeUndefined();
+              expect(errors).toStrictEqual([]);
               expect(path).toEqual([]);
               expect(value).toBe('value');
               expect(data).toBe(true);
@@ -1807,64 +1913,66 @@ export function runProviderTest<
 
         describe(Method.Update, () => {
           test('GIVEN provider w/o data THEN returns payload w/ missing data error', async () => {
-            const payload = await provider[Method.Update]({ method: Method.Update, key: 'key', hook: (value) => value });
+            const payload = await provider[Method.Update]({ method: Method.Update, errors: [], key: 'key', hook: (value) => value });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, hook } = payload;
+            const { method, trigger, errors, key, hook } = payload;
 
             expect(method).toBe(Method.Update);
             expect(trigger).toBeUndefined();
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.identifier).toBe(CommonIdentifiers.MissingData);
+            expect(errors.length).toBe(1);
+            expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
             expect(key).toBe('key');
             expect(typeof hook).toBe('function');
           });
 
           test('GIVEN provider w/ data at key THEN returns payload w/ data AND updates value at key', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
             const payload = await provider[Method.Update]({
               method: Method.Update,
+              errors: [],
               key: 'key',
               hook: (value) => (value as string).toUpperCase()
             });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, hook } = payload;
+            const { method, trigger, errors, key, hook } = payload;
 
             expect(method).toBe(Method.Update);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(typeof hook).toBe('function');
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: [] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: [] });
 
             expect(get.data).toEqual('VALUE');
           });
 
           test('GIVEN provider w/ data at path THEN returns payload w/ data AND updates value at path', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: ['path'], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: ['path'], value: 'value' });
 
             const payload = await provider[Method.Update]({
               method: Method.Update,
+              errors: [],
               key: 'key',
               hook: (value) => (value as string).toUpperCase()
             });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, key, hook } = payload;
+            const { method, trigger, errors, key, hook } = payload;
 
             expect(method).toBe(Method.Update);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(key).toBe('key');
             expect(typeof hook).toBe('function');
 
-            const get = await provider[Method.Get]({ method: Method.Get, key: 'key', path: ['path'] });
+            const get = await provider[Method.Get]({ method: Method.Get, errors: [], key: 'key', path: ['path'] });
 
             expect(get.data).toEqual('VALUE');
           });
@@ -1872,30 +1980,30 @@ export function runProviderTest<
 
         describe(Method.Values, () => {
           test('GIVEN provider w/o data THEN returns payload w/o data', async () => {
-            const payload = await provider[Method.Values]({ method: Method.Values });
+            const payload = await provider[Method.Values]({ method: Method.Values, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Values);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual([]);
           });
 
           test('GIVEN provider w/ data THEN returns payload w/ data', async () => {
-            await provider[Method.Set]({ method: Method.Set, key: 'key', path: [], value: 'value' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-            const payload = await provider[Method.Values]({ method: Method.Values });
+            const payload = await provider[Method.Values]({ method: Method.Values, errors: [] });
 
             expect(typeof payload).toBe('object');
 
-            const { method, trigger, error, data } = payload;
+            const { method, trigger, errors, data } = payload;
 
             expect(method).toBe(Method.Values);
             expect(trigger).toBeUndefined();
-            expect(error).toBeUndefined();
+            expect(errors).toStrictEqual([]);
             expect(data).toEqual(['value']);
           });
         });
@@ -1903,7 +2011,7 @@ export function runProviderTest<
         describe(Method.Each, () => {
           test('GIVEN provider w/o data THEN loops 0 times', () => {
             const mockCallback = jest.fn(() => true);
-            const payload = provider[Method.Each]({ method: Method.Each, hook: () => mockCallback() });
+            const payload = provider[Method.Each]({ method: Method.Each, errors: [], hook: () => mockCallback() });
 
             expect(typeof payload).toBe('object');
             expect(mockCallback.mock.calls.length).toBe(0);
@@ -1912,11 +2020,11 @@ export function runProviderTest<
           test('GIVEN provider w/ data THEN loops x times THEN clears', async () => {
             const mockCallback = jest.fn((..._) => true);
 
-            await provider[Method.Set]({ method: Method.Set, key: 'firstKey', path: [], value: 'firstValue' });
-            await provider[Method.Set]({ method: Method.Set, key: 'secondKey', path: [], value: 'secondValue' });
-            await provider[Method.Set]({ method: Method.Set, key: 'thirdKey', path: [], value: 'thirdValue' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'firstKey', path: [], value: 'firstValue' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'secondKey', path: [], value: 'secondValue' });
+            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'thirdKey', path: [], value: 'thirdValue' });
 
-            const payload = await provider[Method.Each]({ method: Method.Each, hook: mockCallback });
+            const payload = await provider[Method.Each]({ method: Method.Each, errors: [], hook: mockCallback });
 
             expect(typeof payload).toBe('object');
             expect(mockCallback.mock.calls.length).toBe(3);


### PR DESCRIPTION
<details>
<summary>

## Commit Body

</summary>

BREAKING CHANGE: Removed the \`Payload#error\` property.
BREAKING CHANGE: Moved \`JoshProviderErrorOptions\` to the \`JoshProviderError\` namespace.

</details>