### PR TITLE
chore(runProviderTest): remove from main exports

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -4,7 +4,8 @@
   "description": "A core Josh utility to create providers",
   "author": "Évelyne Lachance <eslachance@gmail.com> (https://evie.codes/)",
   "contributors": [
-    "Hezekiah Hendry <hezekiah.hendry@gmail.com>"
+    "Hezekiah Hendry <hezekiah.hendry@gmail.com>",
+    "DanCodes <dan@dancodes.online>"
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -12,9 +13,18 @@
   "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "import": [
+      "./dist/index.mjs",
+      "./dist/tests.mjs"
+    ],
+    "require": [
+      "./dist/index.js",
+      "./dist/tests.js"
+    ],
+    "types": [
+      "./dist/index.js",
+      "./dist/tests.js"
+    ]
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/provider/rollup.config.ts
+++ b/packages/provider/rollup.config.ts
@@ -24,7 +24,7 @@ const main = defineConfig({
 });
 
 const tests = defineConfig({
-  input: './src/tests/runProviderTest.ts',
+  input: './src/tests/index.ts',
   output: [
     {
       file: './dist/tests.js',

--- a/packages/provider/rollup.config.ts
+++ b/packages/provider/rollup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'rollup';
 import cleaner from 'rollup-plugin-cleaner';
 import typescript from 'rollup-plugin-typescript2';
 
-export default defineConfig({
+const main = defineConfig({
   input: './src/index.ts',
   output: [
     {
@@ -19,6 +19,30 @@ export default defineConfig({
       sourcemap: true
     }
   ],
-  external: ['@sapphire/utilities', 'reflect-metadata', 'vitest'],
+  external: ['@sapphire/utilities', 'reflect-metadata'],
   plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })]
 });
+
+const tests = defineConfig({
+  input: './src/tests/runProviderTest.ts',
+  output: [
+    {
+      file: './dist/tests.js',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true
+    },
+    {
+      file: './dist/tests.mjs',
+      format: 'es',
+      exports: 'named',
+      sourcemap: true
+    }
+  ],
+  external: ['@sapphire/utilities', 'reflect-metadata', 'vitest'],
+  plugins: [typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })]
+});
+
+const config = [main, tests];
+
+export default defineConfig(config);

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -7,4 +7,3 @@ export * from './lib/structures/JoshMiddlewareStore';
 export * from './lib/structures/JoshProvider';
 export * from './lib/structures/JoshProviderError';
 export * from './lib/types';
-export * from './tests/runProviderTest';

--- a/packages/provider/src/tests/index.ts
+++ b/packages/provider/src/tests/index.ts
@@ -1,0 +1,1 @@
+export * from './runProviderTest';


### PR DESCRIPTION
Prevents the requirement of `vitest` unless attempting to get tests