### PR TITLE
fix(provider): `Method.Random[Key]` behaviour

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /packages/serialize/**/*.ts @RealShadowNova
-/packages/provider/**/*.ts @RealShadowNova
+/packages/provider/**/*.ts @RealShadowNova @WilsontheWolf
 
 /.github/ @RealShadowNova
 /.husky/ @RealShadowNova

--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -347,12 +347,12 @@ export abstract class JoshProvider<StoredValue = unknown> {
 
   /**
    * A method which gets random value(s).
-   * Whether duplicates are allowed or not are controlled by `Payload.Random#duplicates` option.
+   * Whether duplicates are allowed or not are controlled by `Payload.Random#unique` option.
    * The amount of values returned is controlled by `Payload.Random#count` option.
    *
    * An error should be pushed to the payload and immediately return, if any of the following occurs:
-   * - The provider size is 0, and duplicates is enabled - `CommonIdentifiers.MissingData`
-   * - Duplicates is disabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
+   * - Unique is disabled and the provider size is 0 - `CommonIdentifiers.MissingData`
+   * - Unique is enabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
    * @since 1.0.0
    * @param payload The payload sent by this provider's Josh instance.
    * @returns The payload (modified), originally sent by this provider's Josh instance.
@@ -361,12 +361,12 @@ export abstract class JoshProvider<StoredValue = unknown> {
 
   /**
    * A method which gets random key(s).
-   * Whether duplicates are allowed or not are controlled by `Payload.RandomKey#duplicates` option.
+   * Whether duplicates are allowed or not are controlled by `Payload.RandomKey#unique` option.
    * The amount of keys returned is controlled by `Payload.RandomKey#count` option.
    *
    * An error should be pushed to the payload and immediately return, if any of the following occurs:
-   * - The provider size is 0, and duplicates is enabled - `CommonIdentifiers.MissingData`
-   * - Duplicates is disabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
+   * - Unique is disabled and the provider size is 0  - `CommonIdentifiers.MissingData`
+   * - Unique is enabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
    * @since 1.0.0
    * @param payload The payload sent by this provider's Josh instance.
    * @returns The payload (modified), originally sent by this provider's Josh instance.

--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -349,6 +349,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * A method which gets random value(s).
    * Whether duplicates are allowed or not are controlled by `Payload.Random#duplicates` option.
    * The amount of values returned is controlled by `Payload.Random#count` option.
+   *
+   * An error should be pushed to the payload and immediately return, if any of the following occurs:
+   * - The provider size is 0, and duplicates is enabled - `CommonIdentifiers.MissingData`
+   * - Duplicates is disabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
    * @since 1.0.0
    * @param payload The payload sent by this provider's Josh instance.
    * @returns The payload (modified), originally sent by this provider's Josh instance.
@@ -359,6 +363,10 @@ export abstract class JoshProvider<StoredValue = unknown> {
    * A method which gets random key(s).
    * Whether duplicates are allowed or not are controlled by `Payload.RandomKey#duplicates` option.
    * The amount of keys returned is controlled by `Payload.RandomKey#count` option.
+   *
+   * An error should be pushed to the payload and immediately return, if any of the following occurs:
+   * - The provider size is 0, and duplicates is enabled - `CommonIdentifiers.MissingData`
+   * - Duplicates is disabled and the provider size is less then the count - `CommonIdentifiers.InvalidCount`
    * @since 1.0.0
    * @param payload The payload sent by this provider's Josh instance.
    * @returns The payload (modified), originally sent by this provider's Josh instance.

--- a/packages/provider/src/lib/types/Payload.ts
+++ b/packages/provider/src/lib/types/Payload.ts
@@ -496,10 +496,10 @@ export namespace Payload {
     count: number;
 
     /**
-     * Whether to allow duplicate values.
+     * Whether values must be unique or not.
      * @since 1.0.0
      */
-    duplicates: boolean;
+    unique: boolean;
   }
 
   /**
@@ -516,10 +516,10 @@ export namespace Payload {
     count: number;
 
     /**
-     * Whether to allow duplicate keys.
+     * Whether keys must be unique or not.
      * @since 1.0.0
      */
-    duplicates: boolean;
+    unique: boolean;
   }
 
   /**

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -1661,9 +1661,9 @@ export function runProviderTest<
         });
 
         describe(Method.Random, () => {
-          describe('Duplicates Are Not Allowed', () => {
+          describe('Values must be unique', () => {
             test('GIVEN provider w/o data THEN adds error', async () => {
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1679,7 +1679,7 @@ export function runProviderTest<
             test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, duplicates: false });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1695,7 +1695,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1708,9 +1708,9 @@ export function runProviderTest<
             });
           });
 
-          describe('Duplicates Are Allowed', () => {
+          describe("Values don't have to be unique", () => {
             test('GIVEN provider w/o data THEN adds error', async () => {
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: true });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, unique: false });
 
               expect(typeof payload).toBe('object');
 
@@ -1726,7 +1726,7 @@ export function runProviderTest<
             test('GIVEN provider w/ 1 doc THEN returns payload w/ data from random', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, duplicates: true });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, unique: false });
 
               expect(typeof payload).toBe('object');
 
@@ -1741,7 +1741,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: true });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, unique: false });
 
               expect(typeof payload).toBe('object');
 
@@ -1756,9 +1756,9 @@ export function runProviderTest<
         });
 
         describe(Method.RandomKey, () => {
-          describe('Duplicates Are Not Allowed', () => {
+          describe('Values must be unique', () => {
             test('GIVEN provider w/o data THEN adds error', async () => {
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1774,7 +1774,7 @@ export function runProviderTest<
             test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1790,7 +1790,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, unique: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1803,9 +1803,9 @@ export function runProviderTest<
             });
           });
 
-          describe('Duplicates Are Allowed', () => {
+          describe("Values don't have to be unique", () => {
             test('GIVEN provider w/o data THEN adds error', async () => {
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: true });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, unique: false });
 
               expect(typeof payload).toBe('object');
 
@@ -1821,7 +1821,7 @@ export function runProviderTest<
             test('GIVEN provider w/ 1 doc THEN returns payload w/ data from randomKey', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: true });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, unique: false });
 
               expect(typeof payload).toBe('object');
 
@@ -1836,7 +1836,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: true });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, unique: false });
 
               expect(typeof payload).toBe('object');
 

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -1805,7 +1805,7 @@ export function runProviderTest<
 
           describe('Duplicates Are Allowed', () => {
             test('GIVEN provider w/o data THEN adds error', async () => {
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1821,7 +1821,7 @@ export function runProviderTest<
             test('GIVEN provider w/ 1 doc THEN returns payload w/ data from randomKey', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: true });
 
               expect(typeof payload).toBe('object');
 
@@ -1836,7 +1836,7 @@ export function runProviderTest<
             test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
               await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: true });
 
               expect(typeof payload).toBe('object');
 

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -1661,94 +1661,192 @@ export function runProviderTest<
         });
 
         describe(Method.Random, () => {
-          test('GIVEN provider w/o data THEN returns payload w/o data from random', async () => {
-            const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
+          describe('Duplicates Are Not Allowed', () => {
+            test('GIVEN provider w/o data THEN adds error', async () => {
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
 
-            expect(typeof payload).toBe('object');
+              expect(typeof payload).toBe('object');
 
-            const { method, trigger, errors, data } = payload;
+              const { method, trigger, errors, data } = payload;
 
-            expect(method).toBe(Method.Random);
-            expect(trigger).toBeUndefined();
-            expect(errors).toStrictEqual([]);
-            expect(data).toStrictEqual([]);
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
+              expect(data).toBe(undefined);
+            });
+
+            test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, duplicates: false });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
+              expect(data).toBe(undefined);
+            });
+
+            test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['value']);
+            });
           });
 
-          test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
-            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+          describe('Duplicates Are Allowed', () => {
+            test('GIVEN provider w/o data THEN adds error', async () => {
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: true });
 
-            const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, duplicates: false });
+              expect(typeof payload).toBe('object');
 
-            expect(typeof payload).toBe('object');
+              const { method, trigger, errors, data } = payload;
 
-            const { method, trigger, errors, data } = payload;
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
+              expect(data).toBe(undefined);
+            });
 
-            expect(method).toBe(Method.Random);
-            expect(trigger).toBeUndefined();
-            expect(errors.length).toBe(1);
-            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
-            expect(data).toBe(undefined);
-          });
+            test('GIVEN provider w/ 1 doc THEN returns payload w/ data from random', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-          test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
-            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 2, duplicates: true });
 
-            const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: false });
+              expect(typeof payload).toBe('object');
 
-            expect(typeof payload).toBe('object');
+              const { method, trigger, errors, data } = payload;
 
-            const { method, trigger, errors, data } = payload;
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['value', 'value']);
+            });
 
-            expect(method).toBe(Method.Random);
-            expect(trigger).toBeUndefined();
-            expect(errors).toStrictEqual([]);
-            expect(data).toEqual(['value']);
+            test('GIVEN provider w/ data THEN returns payload w/ data from random', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.Random]({ method: Method.Random, errors: [], count: 1, duplicates: true });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.Random);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['value']);
+            });
           });
         });
 
         describe(Method.RandomKey, () => {
-          test('GIVEN provider w/o data THEN returns payload w/o data from randomKey', async () => {
-            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+          describe('Duplicates Are Not Allowed', () => {
+            test('GIVEN provider w/o data THEN adds error', async () => {
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
 
-            expect(typeof payload).toBe('object');
+              expect(typeof payload).toBe('object');
 
-            const { method, trigger, errors, data } = payload;
+              const { method, trigger, errors, data } = payload;
 
-            expect(method).toBe(Method.RandomKey);
-            expect(trigger).toBeUndefined();
-            expect(errors).toStrictEqual([]);
-            expect(data).toStrictEqual([]);
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
+              expect(data).toBe(undefined);
+            });
+
+            test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: false });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
+              expect(data).toBe(undefined);
+            });
+
+            test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['key']);
+            });
           });
 
-          test('GIVEN provider w/ 1 doc THEN adds error w/ count > 1', async () => {
-            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+          describe('Duplicates Are Allowed', () => {
+            test('GIVEN provider w/o data THEN adds error', async () => {
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
 
-            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: false });
+              expect(typeof payload).toBe('object');
 
-            expect(typeof payload).toBe('object');
+              const { method, trigger, errors, data } = payload;
 
-            const { method, trigger, errors, data } = payload;
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors.length).toBe(1);
+              expect(errors[0].identifier).toBe(CommonIdentifiers.MissingData);
+              expect(data).toBe(undefined);
+            });
 
-            expect(method).toBe(Method.RandomKey);
-            expect(trigger).toBeUndefined();
-            expect(errors.length).toBe(1);
-            expect(errors[0].identifier).toBe(CommonIdentifiers.InvalidCount);
-            expect(data).toBe(undefined);
-          });
+            test('GIVEN provider w/ 1 doc THEN returns payload w/ data from randomKey', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
 
-          test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
-            await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 2, duplicates: false });
 
-            const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+              expect(typeof payload).toBe('object');
 
-            expect(typeof payload).toBe('object');
+              const { method, trigger, errors, data } = payload;
 
-            const { method, trigger, errors, data } = payload;
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['key', 'key']);
+            });
 
-            expect(method).toBe(Method.RandomKey);
-            expect(trigger).toBeUndefined();
-            expect(errors).toStrictEqual([]);
-            expect(data).toEqual(['key']);
+            test('GIVEN provider w/ data THEN returns payload w/ data from randomKey', async () => {
+              await provider[Method.Set]({ method: Method.Set, errors: [], key: 'key', path: [], value: 'value' });
+
+              const payload = await provider[Method.RandomKey]({ method: Method.RandomKey, errors: [], count: 1, duplicates: false });
+
+              expect(typeof payload).toBe('object');
+
+              const { method, trigger, errors, data } = payload;
+
+              expect(method).toBe(Method.RandomKey);
+              expect(trigger).toBeUndefined();
+              expect(errors).toStrictEqual([]);
+              expect(data).toEqual(['key']);
+            });
           });
         });
 


### PR DESCRIPTION
This changes the randomKey and random error behaviour as discussed in discord.

### Commit Body
```
BREAKING CHANGE: `Payload.Random#duplicates` has been renamed to `#unique`.
BREAKING CHANGE: `Payload.RandomKey#duplicates` has been renamed to `#unique`.
```