### PR TITLE
feat(eslint-config): set curly to default all

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,14 @@
 {
-  "eslint.validate": ["typescript"],
-  "editor.tabSize": 2,
-  "editor.useTabStops": false,
-  "editor.insertSpaces": true,
-  "editor.detectIndentation": false,
   "editor.codeActionsOnSave": {
     "source.fixAll": true,
     "source.fixAll.eslint": true,
     "source.organizeImports": true
   },
+  "editor.detectIndentation": false,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.useTabStops": false,
+  "eslint.validate": ["typescript"],
   "files.eol": "\n",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "git+https://github.com/josh-development/utilities.git"
   },
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7.0.0"
   },
   "lint-staged": {

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -2,13 +2,31 @@
   "extends": "@sapphire",
   "rules": {
     "@typescript-eslint/class-literal-property-style": "off",
-    "@typescript-eslint/dot-notation": ["error", { "allowPrivateClassPropertyAccess": true, "allowProtectedClassPropertyAccess": true }],
+    "@typescript-eslint/comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "enums": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never",
+        "generics": "never",
+        "imports": "always-multiline",
+        "objects": "always-multiline",
+        "tuples": "always-multiline"
+      }
+    ],
+    "@typescript-eslint/dot-notation": [
+      "error",
+      {
+        "allowPrivateClassPropertyAccess": true,
+        "allowProtectedClassPropertyAccess": true
+      }
+    ],
     "@typescript-eslint/member-ordering": [
       "error",
       {
         "default": [
           "signature",
-
           ["public-instance-field", "public-decorated-field"],
           "public-abstract-field",
           ["protected-instance-field", "protected-decorated-field"],
@@ -16,12 +34,10 @@
           ["private-instance-field", "private-decorated-field"],
           ["instance-field", "decorated-field"],
           "abstract-field",
-
           "public-constructor",
           "protected-constructor",
           "private-constructor",
           "constructor",
-
           ["public-instance-get", "public-decorated-get"],
           ["public-instance-set", "public-decorated-set"],
           "public-abstract-get",
@@ -36,7 +52,6 @@
           ["instance-set", "decorated-set"],
           "abstract-get",
           "abstract-set",
-
           ["public-instance-method", "public-decorated-method"],
           "public-abstract-method",
           ["protected-instance-method", "protected-decorated-method"],
@@ -44,12 +59,10 @@
           ["private-instance-method", "private-decorated-method"],
           ["instance-method", "decorated-method"],
           "abstract-method",
-
           "public-static-field",
           "protected-static-field",
           "private-static-field",
           "static-field",
-
           "public-static-get",
           "public-static-set",
           "protected-static-get",
@@ -58,7 +71,6 @@
           "private-static-set",
           "static-get",
           "static-set",
-
           "public-static-method",
           "protected-static-method",
           "private-static-method",
@@ -67,20 +79,41 @@
       }
     ],
     "@typescript-eslint/no-namespace": "off",
-    "curly": ["error"],
-    "no-lone-blocks": "error",
-    "no-tabs": "error",
-    "padding-line-between-statements": "off",
     "@typescript-eslint/padding-line-between-statements": [
       "error",
-      { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*" },
-      { "blankLine": "always", "prev": "*", "next": ["const", "let", "var"] },
-      { "blankLine": "never", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] },
-      { "blankLine": "never", "prev": "case", "next": "case" },
-      { "blankLine": "never", "prev": "for", "next": "for" },
-      { "blankLine": "never", "prev": "if", "next": "if" },
       {
         "blankLine": "always",
+        "next": "*",
+        "prev": ["const", "let", "var"]
+      },
+      {
+        "blankLine": "always",
+        "next": ["const", "let", "var"],
+        "prev": "*"
+      },
+      {
+        "blankLine": "never",
+        "next": ["const", "let", "var"],
+        "prev": ["const", "let", "var"]
+      },
+      {
+        "blankLine": "never",
+        "next": "case",
+        "prev": "case"
+      },
+      {
+        "blankLine": "never",
+        "next": "for",
+        "prev": "for"
+      },
+      {
+        "blankLine": "never",
+        "next": "if",
+        "prev": "if"
+      },
+      {
+        "blankLine": "always",
+        "next": "*",
         "prev": [
           "block-like",
           "break",
@@ -95,24 +128,18 @@
           "return",
           "switch",
           "try"
-        ],
-        "next": "*"
+        ]
       },
-      { "blankLine": "always", "prev": "*", "next": ["case", "default", "interface", "type"] }
+      {
+        "blankLine": "always",
+        "next": ["case", "default", "interface", "type"],
+        "prev": "*"
+      }
     ],
     "comma-dangle": "off",
-    "@typescript-eslint/comma-dangle": [
-      "error",
-      {
-        "arrays": "always-multiline",
-        "objects": "always-multiline",
-        "imports": "always-multiline",
-        "exports": "always-multiline",
-        "functions": "never",
-        "enums": "always-multiline",
-        "generics": "never",
-        "tuples": "always-multiline"
-      }
-    ]
+    "curly": ["error"],
+    "no-lone-blocks": "error",
+    "no-tabs": "error",
+    "padding-line-between-statements": "off"
   }
 }

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -67,7 +67,7 @@
       }
     ],
     "@typescript-eslint/no-namespace": "off",
-    "curly": ["error", "multi-line"],
+    "curly": ["error"],
     "no-lone-blocks": "error",
     "no-tabs": "error",
     "padding-line-between-statements": [

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -98,7 +98,21 @@
         ],
         "next": "*"
       },
-      { "blankLine": "always", "prev": "*", "next": ["case", "default"] }
+      { "blankLine": "always", "prev": "*", "next": ["case", "default", "interface", "type"] }
+    ],
+    "comma-dangle": "off",
+    "@typescript-eslint/comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never",
+        "enums": "always-multiline",
+        "generics": "never",
+        "tuples": "always-multiline"
+      }
     ]
   }
 }

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -70,7 +70,8 @@
     "curly": ["error"],
     "no-lone-blocks": "error",
     "no-tabs": "error",
-    "padding-line-between-statements": [
+    "padding-line-between-statements": "off",
+    "@typescript-eslint/padding-line-between-statements": [
       "error",
       { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*" },
       { "blankLine": "always", "prev": "*", "next": ["const", "let", "var"] },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -40,7 +40,7 @@
     "eslint-config.json"
   ],
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7"
   },
   "keywords": [

--- a/packages/prettier-config/.prettierrc.json
+++ b/packages/prettier-config/.prettierrc.json
@@ -6,6 +6,6 @@
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "useTabs": false
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -33,7 +33,7 @@
     ".prettierrc.json"
   ],
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7"
   },
   "keywords": [

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -58,7 +58,7 @@
     "tests.d.ts"
   ],
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7"
   },
   "keywords": [],

--- a/packages/provider/rollup.config.ts
+++ b/packages/provider/rollup.config.ts
@@ -10,17 +10,17 @@ const lib = defineConfig({
       file: './dist/index.js',
       format: 'cjs',
       exports: 'named',
-      sourcemap: true
+      sourcemap: true,
     },
     {
       file: './dist/index.mjs',
       format: 'es',
       exports: 'named',
-      sourcemap: true
-    }
+      sourcemap: true,
+    },
   ],
   external: ['@sapphire/utilities', 'reflect-metadata'],
-  plugins: [typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })]
+  plugins: [typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })],
 });
 
 const tests = defineConfig({
@@ -30,17 +30,17 @@ const tests = defineConfig({
       file: './dist/tests/index.js',
       format: 'cjs',
       exports: 'named',
-      sourcemap: true
+      sourcemap: true,
     },
     {
       file: './dist/tests/index.mjs',
       format: 'es',
       exports: 'named',
-      sourcemap: true
-    }
+      sourcemap: true,
+    },
   ],
   external: ['@sapphire/utilities', 'reflect-metadata', 'vitest'],
-  plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })]
+  plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })],
 });
 
 const config = [tests, lib];

--- a/packages/provider/src/lib/decorators/ApplyMiddlewareOptions.ts
+++ b/packages/provider/src/lib/decorators/ApplyMiddlewareOptions.ts
@@ -26,7 +26,7 @@ export function ApplyMiddlewareOptions(options: PartialRequired<JoshMiddleware.O
         const post = Reflect.getMetadata(Trigger.PostProvider, target.constructor) ?? [];
 
         return new ctor(context, { ...options, conditions: { [Trigger.PreProvider]: pre, [Trigger.PostProvider]: post } });
-      }
+      },
     })
   );
 }

--- a/packages/provider/src/lib/decorators/PostProvider.ts
+++ b/packages/provider/src/lib/decorators/PostProvider.ts
@@ -6,10 +6,14 @@ import { Trigger } from '../types';
  */
 export function PostProvider(): MethodDecorator {
   return (target, propertyKey) => {
-    if (!Reflect.hasMetadata(Trigger.PostProvider, target.constructor)) Reflect.defineMetadata(Trigger.PostProvider, [], target.constructor);
+    if (!Reflect.hasMetadata(Trigger.PostProvider, target.constructor)) {
+      Reflect.defineMetadata(Trigger.PostProvider, [], target.constructor);
+    }
 
     const methods = Reflect.getMetadata(Trigger.PostProvider, target.constructor);
 
-    if (Array.isArray(methods)) methods.push(propertyKey);
+    if (Array.isArray(methods)) {
+      methods.push(propertyKey);
+    }
   };
 }

--- a/packages/provider/src/lib/decorators/PreProvider.ts
+++ b/packages/provider/src/lib/decorators/PreProvider.ts
@@ -6,10 +6,14 @@ import { Trigger } from '../types';
  */
 export function PreProvider(): MethodDecorator {
   return (target, propertyKey) => {
-    if (!Reflect.hasMetadata(Trigger.PreProvider, target.constructor)) Reflect.defineMetadata(Trigger.PreProvider, [], target.constructor);
+    if (!Reflect.hasMetadata(Trigger.PreProvider, target.constructor)) {
+      Reflect.defineMetadata(Trigger.PreProvider, [], target.constructor);
+    }
 
     const methods = Reflect.getMetadata(Trigger.PreProvider, target.constructor);
 
-    if (Array.isArray(methods)) methods.push(propertyKey);
+    if (Array.isArray(methods)) {
+      methods.push(propertyKey);
+    }
   };
 }

--- a/packages/provider/src/lib/decorators/utils/createProxy.ts
+++ b/packages/provider/src/lib/decorators/utils/createProxy.ts
@@ -5,6 +5,6 @@ export function createProxy<T extends object>(target: T, handler: Omit<ProxyHand
       const value = Reflect.get(target, property);
 
       return typeof value === 'function' ? (...args: readonly unknown[]) => value.apply(target, args) : value;
-    }
+    },
   });
 }

--- a/packages/provider/src/lib/functions/resolveCommonIdentifier.ts
+++ b/packages/provider/src/lib/functions/resolveCommonIdentifier.ts
@@ -15,9 +15,17 @@ export function resolveCommonIdentifier(identifier: string, metadata: Record<str
     case CommonIdentifiers.InvalidDataType: {
       const { key, path = [], type } = metadata;
 
-      if (typeof key !== 'string') return null;
-      if (!Array.isArray(path)) return null;
-      if (typeof type !== 'string') return null;
+      if (typeof key !== 'string') {
+        return null;
+      }
+
+      if (!Array.isArray(path)) {
+        return null;
+      }
+
+      if (typeof type !== 'string') {
+        return null;
+      }
 
       return path.length === 0
         ? `The data at "${key}" is invalid. Expected type: ${type.toUpperCase()}`
@@ -27,7 +35,9 @@ export function resolveCommonIdentifier(identifier: string, metadata: Record<str
     case CommonIdentifiers.InvalidValueType: {
       const { type } = metadata;
 
-      if (typeof type !== 'string') return null;
+      if (typeof type !== 'string') {
+        return null;
+      }
 
       return `The "value" parameter is invalid. Expected type: ${type.toUpperCase()}`;
     }
@@ -35,9 +45,17 @@ export function resolveCommonIdentifier(identifier: string, metadata: Record<str
     case CommonIdentifiers.MissingData: {
       const { key, path = [], duplicates, count } = metadata;
 
-      if (typeof duplicates === 'boolean' && typeof count === 'number') return `There is no data present.`;
-      if (typeof key !== 'string') return null;
-      if (!Array.isArray(path)) return null;
+      if (typeof duplicates === 'boolean' && typeof count === 'number') {
+        return `There is no data present.`;
+      }
+
+      if (typeof key !== 'string') {
+        return null;
+      }
+
+      if (!Array.isArray(path)) {
+        return null;
+      }
 
       return path.length === 0 ? `The data at "${key}" does not exist.` : `The data at "${key}.${path.join('.')}" does not exist.`;
     }

--- a/packages/provider/src/lib/structures/JoshMiddleware.ts
+++ b/packages/provider/src/lib/structures/JoshMiddleware.ts
@@ -69,7 +69,9 @@ export abstract class JoshMiddleware<ContextData extends JoshMiddleware.Context,
 
     const { name, conditions } = options;
 
-    if (!name) throw this.error(JoshMiddleware.CommonIdentifiers.NameNotFound);
+    if (!name) {
+      throw this.error(JoshMiddleware.CommonIdentifiers.NameNotFound);
+    }
 
     this.name = name;
     this.conditions = conditions ?? { [Trigger.PreProvider]: [], [Trigger.PostProvider]: [] };
@@ -86,7 +88,9 @@ export abstract class JoshMiddleware<ContextData extends JoshMiddleware.Context,
    * @since 1.0.0
    */
   protected get provider(): JoshProvider<StoredValue> {
-    if (this.store === undefined) throw this.error(JoshMiddleware.CommonIdentifiers.StoreNotFound);
+    if (this.store === undefined) {
+      throw this.error(JoshMiddleware.CommonIdentifiers.StoreNotFound);
+    }
 
     return this.store.provider;
   }
@@ -105,14 +109,18 @@ export abstract class JoshMiddleware<ContextData extends JoshMiddleware.Context,
     if (version.major < this.version.major) {
       const { allowMigrations } = this.context;
 
-      if (!allowMigrations) throw this.error(JoshMiddleware.CommonIdentifiers.NeedsMigration);
+      if (!allowMigrations) {
+        throw this.error(JoshMiddleware.CommonIdentifiers.NeedsMigration);
+      }
 
       const migration = this.migrations.find(
         (migration) =>
           migration.version.major === version.major && migration.version.minor <= version.minor && migration.version.patch <= version.patch
       );
 
-      if (migration === undefined) throw this.error(JoshMiddleware.CommonIdentifiers.MigrationNotFound, { version });
+      if (migration === undefined) {
+        throw this.error(JoshMiddleware.CommonIdentifiers.MigrationNotFound, { version });
+      }
 
       const { major, minor, patch } = version;
 
@@ -313,7 +321,9 @@ export abstract class JoshMiddleware<ContextData extends JoshMiddleware.Context,
   protected resolveIdentifier(identifier: string, metadata: Record<string, unknown> = {}): string {
     const result = resolveCommonIdentifier(identifier, metadata);
 
-    if (result !== null) return result;
+    if (result !== null) {
+      return result;
+    }
 
     switch (identifier) {
       case JoshMiddleware.CommonIdentifiers.MigrationNotFound: {

--- a/packages/provider/src/lib/structures/JoshMiddleware.ts
+++ b/packages/provider/src/lib/structures/JoshMiddleware.ts
@@ -300,14 +300,14 @@ export abstract class JoshMiddleware<ContextData extends JoshMiddleware.Context,
       return new JoshProviderError({
         identifier: options,
         origin: { type: JoshProviderError.OriginType.Middleware, name: this.constructor.name.replace(/Middleware/, '') },
-        message: this.resolveIdentifier(options, metadata)
+        message: this.resolveIdentifier(options, metadata),
       });
     }
 
     return new JoshProviderError({
       ...options,
       name: options.name ?? `${this.constructor.name}Error`,
-      origin: { type: JoshProviderError.OriginType.Middleware, name: this.constructor.name.replace(/Middleware/, '') }
+      origin: { type: JoshProviderError.OriginType.Middleware, name: this.constructor.name.replace(/Middleware/, '') },
     });
   }
 
@@ -449,6 +449,6 @@ export namespace JoshMiddleware {
 
     NeedsMigration = 'needsMigration',
 
-    StoreNotFound = 'storeNotFound'
+    StoreNotFound = 'storeNotFound',
   }
 }

--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -476,14 +476,14 @@ export abstract class JoshProvider<StoredValue = unknown> {
       return new JoshProviderError({
         identifier: options,
         origin: { type: JoshProviderError.OriginType.Provider, name: this.constructor.name.replace(/Provider/, '') },
-        message: this.resolveIdentifier(options, metadata)
+        message: this.resolveIdentifier(options, metadata),
       });
     }
 
     return new JoshProviderError({
       ...options,
       name: options.name ?? `${this.constructor.name}Error`,
-      origin: { type: JoshProviderError.OriginType.Provider, name: this.constructor.name.replace(/Provider/, '') }
+      origin: { type: JoshProviderError.OriginType.Provider, name: this.constructor.name.replace(/Provider/, '') },
     });
   }
 
@@ -581,6 +581,6 @@ export namespace JoshProvider {
   export enum CommonIdentifiers {
     MigrationNotFound = 'MigrationNotFound',
 
-    NeedsMigration = 'needsMigration'
+    NeedsMigration = 'needsMigration',
   }
 }

--- a/packages/provider/src/lib/structures/JoshProvider.ts
+++ b/packages/provider/src/lib/structures/JoshProvider.ts
@@ -74,14 +74,18 @@ export abstract class JoshProvider<StoredValue = unknown> {
     ) {
       const { allowMigrations } = this.options;
 
-      if (!allowMigrations) throw this.error(JoshProvider.CommonIdentifiers.NeedsMigration);
+      if (!allowMigrations) {
+        throw this.error(JoshProvider.CommonIdentifiers.NeedsMigration);
+      }
 
       const migration = this.migrations.find(
         (migration) =>
           migration.version.major === version.major && migration.version.minor <= version.minor && migration.version.patch <= version.patch
       );
 
-      if (migration === undefined) throw this.error(JoshProvider.CommonIdentifiers.MigrationNotFound, { version });
+      if (migration === undefined) {
+        throw this.error(JoshProvider.CommonIdentifiers.MigrationNotFound, { version });
+      }
 
       const { major, minor, patch } = version;
 
@@ -493,7 +497,9 @@ export abstract class JoshProvider<StoredValue = unknown> {
   protected resolveIdentifier(identifier: string, metadata: Record<string, unknown> = {}): string {
     const result = resolveCommonIdentifier(identifier, metadata);
 
-    if (result !== null) return result;
+    if (result !== null) {
+      return result;
+    }
 
     switch (identifier) {
       case JoshProvider.CommonIdentifiers.MigrationNotFound: {

--- a/packages/provider/src/lib/structures/JoshProviderError.ts
+++ b/packages/provider/src/lib/structures/JoshProviderError.ts
@@ -107,6 +107,6 @@ export namespace JoshProviderError {
   export enum OriginType {
     Provider = 'provider',
 
-    Middleware = 'middleware'
+    Middleware = 'middleware',
   }
 }

--- a/packages/provider/src/lib/types/CommonIdentifiers.ts
+++ b/packages/provider/src/lib/types/CommonIdentifiers.ts
@@ -11,5 +11,5 @@ export enum CommonIdentifiers {
 
   MissingData = 'missingData',
 
-  MissingValue = 'missingValue'
+  MissingValue = 'missingValue',
 }

--- a/packages/provider/src/lib/types/MathOperator.ts
+++ b/packages/provider/src/lib/types/MathOperator.ts
@@ -13,5 +13,5 @@ export enum MathOperator {
 
   Remainder = 'remainder',
 
-  Exponent = 'exponent'
+  Exponent = 'exponent',
 }

--- a/packages/provider/src/lib/types/Method.ts
+++ b/packages/provider/src/lib/types/Method.ts
@@ -59,5 +59,5 @@ export enum Method {
 
   Update = 'update',
 
-  Values = 'values'
+  Values = 'values',
 }

--- a/packages/provider/src/lib/types/Payload.ts
+++ b/packages/provider/src/lib/types/Payload.ts
@@ -157,7 +157,7 @@ export namespace Payload {
 
     Value,
 
-    Path
+    Path,
   }
 
   /**

--- a/packages/provider/src/lib/types/Trigger.ts
+++ b/packages/provider/src/lib/types/Trigger.ts
@@ -5,5 +5,5 @@
 export enum Trigger {
   PreProvider,
 
-  PostProvider
+  PostProvider,
 }

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -40,7 +40,9 @@ export function runProviderTest<
 
         afterAll(async () => {
           await provider[Method.Clear]({ method: Method.Clear, errors: [] });
-          if (typeof cleanup === 'function') await cleanup(provider as CleanupProvider);
+          if (typeof cleanup === 'function') {
+            await cleanup(provider as CleanupProvider);
+          }
         });
 
         describe(Method.AutoKey, () => {

--- a/packages/provider/src/tests/runProviderTest.ts
+++ b/packages/provider/src/tests/runProviderTest.ts
@@ -411,7 +411,7 @@ export function runProviderTest<
                 method: Method.Every,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -431,16 +431,16 @@ export function runProviderTest<
                 errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
-                  { key: 'secondKey', path: [], value: 'value' }
+                  { key: 'secondKey', path: [], value: 'value' },
                 ],
-                overwrite: true
+                overwrite: true,
               });
 
               const payload = await provider[Method.Every]({
                 method: Method.Every,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -462,7 +462,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -483,9 +483,9 @@ export function runProviderTest<
                 errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
-                  { key: 'secondKey', path: [], value: 'value' }
+                  { key: 'secondKey', path: [], value: 'value' },
                 ],
-                overwrite: true
+                overwrite: true,
               });
 
               const payload = await provider[Method.Every]({
@@ -493,7 +493,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -516,7 +516,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['invalid'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -540,7 +540,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['p'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -577,9 +577,9 @@ export function runProviderTest<
                 errors: [],
                 entries: [
                   { key: 'firsKey', path: [], value: 'value' },
-                  { key: 'secondKey', path: [], value: 'value' }
+                  { key: 'secondKey', path: [], value: 'value' },
                 ],
-                overwrite: true
+                overwrite: true,
               });
 
               const payload = await provider[Method.Every]({ method: Method.Every, errors: [], type: Payload.Type.Value, path: [], value: 'value' });
@@ -605,7 +605,7 @@ export function runProviderTest<
                 method: Method.Filter,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -626,7 +626,7 @@ export function runProviderTest<
                 method: Method.Filter,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -648,7 +648,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -671,7 +671,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['invalid'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -695,7 +695,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -719,7 +719,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -743,7 +743,7 @@ export function runProviderTest<
                 method: Method.Find,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -765,7 +765,7 @@ export function runProviderTest<
                 method: Method.Find,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -787,7 +787,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -810,7 +810,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['invalid'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -834,7 +834,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -858,7 +858,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1254,7 +1254,7 @@ export function runProviderTest<
               key: 'key',
               path: [],
               operator: MathOperator.Addition,
-              operand: 1
+              operand: 1,
             });
 
             expect(typeof payload).toBe('object');
@@ -1280,7 +1280,7 @@ export function runProviderTest<
               key: 'key',
               path: ['path'],
               operator: MathOperator.Addition,
-              operand: 1
+              operand: 1,
             });
 
             expect(typeof payload).toBe('object');
@@ -1306,7 +1306,7 @@ export function runProviderTest<
               key: 'key',
               path: [],
               operator: MathOperator.Addition,
-              operand: 1
+              operand: 1,
             });
 
             expect(typeof payload).toBe('object');
@@ -1332,7 +1332,7 @@ export function runProviderTest<
               key: 'key',
               path: ['path'],
               operator: MathOperator.Addition,
-              operand: 1
+              operand: 1,
             });
 
             expect(typeof payload).toBe('object');
@@ -1357,7 +1357,7 @@ export function runProviderTest<
                 method: Method.Partition,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1380,7 +1380,7 @@ export function runProviderTest<
                 method: Method.Partition,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1403,7 +1403,7 @@ export function runProviderTest<
                 method: Method.Partition,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value !== 'value'
+                hook: (value) => value !== 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1427,7 +1427,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1452,7 +1452,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1477,7 +1477,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['invalid'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1503,7 +1503,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1529,7 +1529,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'anotherValue'
+                value: 'anotherValue',
               });
 
               expect(typeof payload).toBe('object');
@@ -1861,7 +1861,7 @@ export function runProviderTest<
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
-                hook: (value: string) => value === 'value'
+                hook: (value: string) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1887,7 +1887,7 @@ export function runProviderTest<
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
-                hook: (value: string) => value === 'value'
+                hook: (value: string) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1917,7 +1917,7 @@ export function runProviderTest<
                 type: Payload.Type.Hook,
                 key: 'key',
                 path: [],
-                hook: (value: string) => value === 'value'
+                hook: (value: string) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1946,7 +1946,7 @@ export function runProviderTest<
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -1972,7 +1972,7 @@ export function runProviderTest<
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2002,7 +2002,7 @@ export function runProviderTest<
                 type: Payload.Type.Value,
                 key: 'key',
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2082,7 +2082,7 @@ export function runProviderTest<
               method: Method.SetMany,
               errors: [],
               entries: [{ key: 'key', path: [], value: 'value' }],
-              overwrite: true
+              overwrite: true,
             });
 
             expect(typeof payload).toBe('object');
@@ -2106,7 +2106,7 @@ export function runProviderTest<
               method: Method.SetMany,
               errors: [],
               entries: [{ key: 'key', path: [], value: 'anotherValue' }],
-              overwrite: false
+              overwrite: false,
             });
 
             expect(typeof payload).toBe('object');
@@ -2134,7 +2134,7 @@ export function runProviderTest<
               method: Method.SetMany,
               errors: [],
               entries: [{ key: 'key', path: [], value: 'anotherValue' }],
-              overwrite: true
+              overwrite: true,
             });
 
             expect(typeof payload).toBe('object');
@@ -2189,7 +2189,7 @@ export function runProviderTest<
                 method: Method.Some,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2210,7 +2210,7 @@ export function runProviderTest<
                 method: Method.Some,
                 errors: [],
                 type: Payload.Type.Hook,
-                hook: (value) => value === 'value'
+                hook: (value) => value === 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2232,7 +2232,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2255,7 +2255,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2278,7 +2278,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['invalid'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2302,7 +2302,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: ['path'],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2324,7 +2324,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2347,7 +2347,7 @@ export function runProviderTest<
                 errors: [],
                 type: Payload.Type.Value,
                 path: [],
-                value: 'value'
+                value: 'value',
               });
 
               expect(typeof payload).toBe('object');
@@ -2387,7 +2387,7 @@ export function runProviderTest<
               method: Method.Update,
               errors: [],
               key: 'key',
-              hook: (value) => (value as string).toUpperCase()
+              hook: (value) => (value as string).toUpperCase(),
             });
 
             expect(typeof payload).toBe('object');
@@ -2412,7 +2412,7 @@ export function runProviderTest<
               method: Method.Update,
               errors: [],
               key: 'key',
-              hook: (value) => ({ path: (value as Record<'path', string>).path.toUpperCase() })
+              hook: (value) => ({ path: (value as Record<'path', string>).path.toUpperCase() }),
             });
 
             expect(typeof payload).toBe('object');

--- a/packages/provider/src/tsconfig.json
+++ b/packages/provider/src/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "../dist",
     "composite": true,
-    "tsBuildInfoFile": "../dist/.tsbuildinfo",
-    "skipLibCheck": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "outDir": "../dist",
+    "rootDir": "./",
+    "skipLibCheck": true,
+    "tsBuildInfoFile": "../dist/.tsbuildinfo"
   },
   "include": ["."]
 }

--- a/packages/provider/tests/lib/structures/JoshProvider.test.ts
+++ b/packages/provider/tests/lib/structures/JoshProvider.test.ts
@@ -16,8 +16,8 @@ describe('JoshProvider', () => {
       {
         version: { major: 1, minor: 0, patch: 0 },
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        run() {}
-      }
+        run() {},
+      },
     ];
 
     public get version() {

--- a/packages/provider/tests/tsconfig.json
+++ b/packages/provider/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./",
     "outDir": "./build",
+    "rootDir": "./",
     "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },

--- a/packages/provider/typedoc.json
+++ b/packages/provider/typedoc.json
@@ -2,6 +2,6 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts"],
   "json": "docs/api.json",
-  "tsconfig": "src/tsconfig.json",
-  "treatWarningsAsErrors": true
+  "treatWarningsAsErrors": true,
+  "tsconfig": "src/tsconfig.json"
 }

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -44,7 +44,7 @@
     "!dist/*.tsbuildinfo"
   ],
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7"
   },
   "keywords": [

--- a/packages/serialize/rollup.config.ts
+++ b/packages/serialize/rollup.config.ts
@@ -10,15 +10,15 @@ export default defineConfig({
       file: './dist/index.js',
       format: 'cjs',
       exports: 'named',
-      sourcemap: true
+      sourcemap: true,
     },
     {
       file: './dist/index.mjs',
       format: 'es',
       exports: 'named',
-      sourcemap: true
-    }
+      sourcemap: true,
+    },
   ],
   external: [],
-  plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })]
+  plugins: [cleaner({ targets: ['./dist'] }), typescript({ tsconfig: resolve(process.cwd(), 'src', 'tsconfig.json') })],
 });

--- a/packages/serialize/src/lib/Serialize.ts
+++ b/packages/serialize/src/lib/Serialize.ts
@@ -173,7 +173,7 @@ export namespace Serialize {
 
     Source = 's',
 
-    Flags = 'f'
+    Flags = 'f',
   }
   export interface Regex {
     [Keying.Source]: string;
@@ -225,6 +225,6 @@ export namespace Serialize {
 
     String = 8,
 
-    Undefined = 1
+    Undefined = 1,
   }
 }

--- a/packages/serialize/src/lib/Serialize.ts
+++ b/packages/serialize/src/lib/Serialize.ts
@@ -8,23 +8,39 @@ export namespace Serialize {
    * @returns The converted data.
    */
   export function toJSON(data: unknown): JSON {
-    if (Array.isArray(data)) return { [Keying.Type]: Type.Array, [Keying.Value]: toJSONArray(data) };
-    else if (typeof data === 'bigint') return { [Keying.Type]: Type.BigInt, [Keying.Value]: data.toString() };
-    else if (typeof data === 'boolean') return { [Keying.Type]: Type.Boolean, [Keying.Value]: data };
-    else if (data instanceof Date) return { [Keying.Type]: Type.Date, [Keying.Value]: data.toJSON() };
-    else if (data instanceof Map) return { [Keying.Type]: Type.Map, [Keying.Value]: toJSONEntries(Array.from(data)) };
-    else if (data === null) return { [Keying.Type]: Type.Null, [Keying.Value]: null };
-    else if (typeof data === 'number') {
-      if (Number.isNaN(data)) return { [Keying.Type]: Type.Number, [Keying.Value]: 'NaN' };
-      if ([Infinity, -Infinity].includes(data)) return { [Keying.Type]: Type.Number, [Keying.Value]: String(data) };
+    if (Array.isArray(data)) {
+      return { [Keying.Type]: Type.Array, [Keying.Value]: toJSONArray(data) };
+    } else if (typeof data === 'bigint') {
+      return { [Keying.Type]: Type.BigInt, [Keying.Value]: data.toString() };
+    } else if (typeof data === 'boolean') {
+      return { [Keying.Type]: Type.Boolean, [Keying.Value]: data };
+    } else if (data instanceof Date) {
+      return { [Keying.Type]: Type.Date, [Keying.Value]: data.toJSON() };
+    } else if (data instanceof Map) {
+      return { [Keying.Type]: Type.Map, [Keying.Value]: toJSONEntries(Array.from(data)) };
+    } else if (data === null) {
+      return { [Keying.Type]: Type.Null, [Keying.Value]: null };
+    } else if (typeof data === 'number') {
+      if (Number.isNaN(data)) {
+        return { [Keying.Type]: Type.Number, [Keying.Value]: 'NaN' };
+      }
+
+      if ([Infinity, -Infinity].includes(data)) {
+        return { [Keying.Type]: Type.Number, [Keying.Value]: String(data) };
+      }
 
       return { [Keying.Type]: Type.Number, [Keying.Value]: data };
-    } else if (isObject(data)) return { [Keying.Type]: Type.Object, [Keying.Value]: toJSONObject(data) };
-    else if (data instanceof RegExp) {
+    } else if (isObject(data)) {
+      return { [Keying.Type]: Type.Object, [Keying.Value]: toJSONObject(data) };
+    } else if (data instanceof RegExp) {
       return { [Keying.Type]: Type.RegExp, [Keying.Value]: { [Keying.Source]: data.source, [Keying.Flags]: data.flags } };
-    } else if (data instanceof Set) return { [Keying.Type]: Type.Set, [Keying.Value]: toJSONArray(Array.from(data)) };
-    else if (typeof data === 'string') return { [Keying.Type]: Type.String, [Keying.Value]: data };
-    else if (data === undefined) return { [Keying.Type]: Type.Undefined, [Keying.Value]: 'undefined' };
+    } else if (data instanceof Set) {
+      return { [Keying.Type]: Type.Set, [Keying.Value]: toJSONArray(Array.from(data)) };
+    } else if (typeof data === 'string') {
+      return { [Keying.Type]: Type.String, [Keying.Value]: data };
+    } else if (data === undefined) {
+      return { [Keying.Type]: Type.Undefined, [Keying.Value]: 'undefined' };
+    }
 
     throw new TypeError(
       `Serialize received an unknown type while formatting: "${data.constructor.name}", see @joshdb/transform for custom serialization`
@@ -34,14 +50,20 @@ export namespace Serialize {
   function toJSONArray(array: unknown[]): JSON[] {
     const json: JSON[] = [];
 
-    for (const value of array) json.push(toJSON(value));
+    for (const value of array) {
+      json.push(toJSON(value));
+    }
+
     return json;
   }
 
   function toJSONEntries(entries: [PropertyKey, unknown][]): [PropertyKey, JSON][] {
     const json: [PropertyKey, JSON][] = [];
 
-    for (const [key, value] of entries) json.push([key, toJSON(value)]);
+    for (const [key, value] of entries) {
+      json.push([key, toJSON(value)]);
+    }
+
     return json;
   }
 
@@ -86,7 +108,9 @@ export namespace Serialize {
         return null;
 
       case Type.Number:
-        if (typeof value === 'string') return Number(value);
+        if (typeof value === 'string') {
+          return Number(value);
+        }
 
         return value;
 
@@ -113,14 +137,20 @@ export namespace Serialize {
   function fromJSONArray(json: JSON[]): unknown[] {
     const arr: unknown[] = [];
 
-    for (const value of json) arr.push(fromJSON(value));
+    for (const value of json) {
+      arr.push(fromJSON(value));
+    }
+
     return arr;
   }
 
   function fromJSONMap(json: [PropertyKey, JSON][]): [PropertyKey, unknown][] {
     const arr: [PropertyKey, unknown][] = [];
 
-    for (const [key, value] of json) arr.push([key, fromJSON(value)]);
+    for (const [key, value] of json) {
+      arr.push([key, fromJSON(value)]);
+    }
+
     return arr;
   }
 

--- a/packages/serialize/src/tsconfig.json
+++ b/packages/serialize/src/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "../dist",
     "composite": true,
+    "outDir": "../dist",
+    "rootDir": "./",
     "tsBuildInfoFile": "../dist/.tsbuildinfo"
   },
   "include": ["."]

--- a/packages/serialize/tests/lib/Serialize.test.ts
+++ b/packages/serialize/tests/lib/Serialize.test.ts
@@ -446,7 +446,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }],
             })
           ).toStrictEqual([rawBigInt]);
         });
@@ -455,7 +455,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }],
             })
           ).toStrictEqual([rawBoolean]);
         });
@@ -464,7 +464,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }],
             })
           ).toStrictEqual([rawDate]);
         });
@@ -473,7 +473,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }],
             })
           ).toStrictEqual([rawNull]);
         });
@@ -483,7 +483,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Array,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }],
               })
             ).toStrictEqual([rawNumber]);
           });
@@ -492,7 +492,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Array,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }],
               })
             ).toStrictEqual([NaN]);
           });
@@ -501,7 +501,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Array,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }],
               })
             ).toStrictEqual([Infinity]);
           });
@@ -510,7 +510,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Array,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }],
               })
             ).toStrictEqual([-Infinity]);
           });
@@ -520,7 +520,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }],
             })
           ).toStrictEqual([rawRegExp]);
         });
@@ -529,7 +529,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }],
             })
           ).toStrictEqual([rawString]);
         });
@@ -538,7 +538,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Array,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }],
             })
           ).toStrictEqual([rawUndefined]);
         });
@@ -561,7 +561,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }]],
             })
           ).toStrictEqual(new Map([['key', rawBigInt]]));
         });
@@ -570,7 +570,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }]],
             })
           ).toStrictEqual(new Map([['key', rawBoolean]]));
         });
@@ -579,7 +579,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }]],
             })
           ).toStrictEqual(new Map([['key', rawDate]]));
         });
@@ -588,7 +588,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }]],
             })
           ).toStrictEqual(new Map([['key', rawNull]]));
         });
@@ -598,7 +598,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Map,
-                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }]]
+                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }]],
               })
             ).toStrictEqual(new Map([['key', rawNumber]]));
           });
@@ -607,7 +607,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Map,
-                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }]]
+                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }]],
               })
             ).toStrictEqual(new Map([['key', NaN]]));
           });
@@ -616,7 +616,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Map,
-                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }]]
+                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }]],
               })
             ).toStrictEqual(new Map([['key', Infinity]]));
           });
@@ -625,7 +625,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Map,
-                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }]]
+                [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }]],
               })
             ).toStrictEqual(new Map([['key', -Infinity]]));
           });
@@ -635,7 +635,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }]],
             })
           ).toStrictEqual(new Map([['key', rawRegExp]]));
         });
@@ -644,7 +644,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }]],
             })
           ).toStrictEqual(new Map([['key', rawString]]));
         });
@@ -653,7 +653,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Map,
-              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }]]
+              [Serialize.Keying.Value]: [['key', { [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }]],
             })
           ).toStrictEqual(new Map([['key', rawUndefined]]));
         });
@@ -686,10 +686,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt } },
             })
           ).toStrictEqual({
-            key: rawBigInt
+            key: rawBigInt,
           });
         });
 
@@ -697,10 +697,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean } },
             })
           ).toStrictEqual({
-            key: rawBoolean
+            key: rawBoolean,
           });
         });
 
@@ -708,10 +708,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate } },
             })
           ).toStrictEqual({
-            key: rawDate
+            key: rawDate,
           });
         });
 
@@ -719,10 +719,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull } },
             })
           ).toStrictEqual({
-            key: rawNull
+            key: rawNull,
           });
         });
 
@@ -731,10 +731,10 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Object,
-                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber } }
+                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber } },
               })
             ).toStrictEqual({
-              key: rawNumber
+              key: rawNumber,
             });
           });
 
@@ -742,10 +742,10 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Object,
-                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' } }
+                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' } },
               })
             ).toStrictEqual({
-              key: NaN
+              key: NaN,
             });
           });
 
@@ -753,10 +753,10 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Object,
-                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' } }
+                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' } },
               })
             ).toStrictEqual({
-              key: Infinity
+              key: Infinity,
             });
           });
 
@@ -764,10 +764,10 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Object,
-                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' } }
+                [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' } },
               })
             ).toStrictEqual({
-              key: -Infinity
+              key: -Infinity,
             });
           });
         });
@@ -776,10 +776,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp } },
             })
           ).toStrictEqual({
-            key: rawRegExp
+            key: rawRegExp,
           });
         });
 
@@ -787,10 +787,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString } },
             })
           ).toStrictEqual({
-            key: rawString
+            key: rawString,
           });
         });
 
@@ -798,10 +798,10 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Object,
-              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined } }
+              [Serialize.Keying.Value]: { key: { [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined } },
             })
           ).toStrictEqual({
-            key: rawUndefined
+            key: rawUndefined,
           });
         });
       });
@@ -815,7 +815,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.BigInt, [Serialize.Keying.Value]: jsonBigInt }],
             })
           ).toStrictEqual(new Set([rawBigInt]));
         });
@@ -824,7 +824,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Boolean, [Serialize.Keying.Value]: jsonBoolean }],
             })
           ).toStrictEqual(new Set([rawBoolean]));
         });
@@ -833,7 +833,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Date, [Serialize.Keying.Value]: jsonDate }],
             })
           ).toStrictEqual(new Set([rawDate]));
         });
@@ -842,7 +842,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Null, [Serialize.Keying.Value]: jsonNull }],
             })
           ).toStrictEqual(new Set([rawNull]));
         });
@@ -852,7 +852,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Set,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: jsonNumber }],
               })
             ).toStrictEqual(new Set([rawNumber]));
           });
@@ -861,7 +861,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Set,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'NaN' }],
               })
             ).toStrictEqual(new Set([NaN]));
           });
@@ -870,7 +870,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Set,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: 'Infinity' }],
               })
             ).toStrictEqual(new Set([Infinity]));
           });
@@ -879,7 +879,7 @@ describe('Serialize', () => {
             expect(
               Serialize.fromJSON({
                 [Serialize.Keying.Type]: Serialize.Type.Set,
-                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }]
+                [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Number, [Serialize.Keying.Value]: '-Infinity' }],
               })
             ).toStrictEqual(new Set([-Infinity]));
           });
@@ -889,7 +889,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.RegExp, [Serialize.Keying.Value]: jsonRegExp }],
             })
           ).toStrictEqual(new Set([rawRegExp]));
         });
@@ -898,7 +898,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.String, [Serialize.Keying.Value]: jsonString }],
             })
           ).toStrictEqual(new Set([rawString]));
         });
@@ -907,7 +907,7 @@ describe('Serialize', () => {
           expect(
             Serialize.fromJSON({
               [Serialize.Keying.Type]: Serialize.Type.Set,
-              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }]
+              [Serialize.Keying.Value]: [{ [Serialize.Keying.Type]: Serialize.Type.Undefined, [Serialize.Keying.Value]: jsonUndefined }],
             })
           ).toStrictEqual(new Set([rawUndefined]));
         });

--- a/packages/serialize/tests/tsconfig.json
+++ b/packages/serialize/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./",
     "outDir": "./build",
+    "rootDir": "./",
     "tsBuildInfoFile": "./build/.tsbuildinfo",
     "types": ["vitest/globals"]
   },

--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -34,7 +34,7 @@
     "tsconfig.json"
   ],
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.20.1",
     "npm": ">=7"
   },
   "keywords": [

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -5,6 +5,6 @@
     "noEmitHelpers": true,
     "lib": ["ESNext"],
     "target": "ES2021",
-    "module": "ESNext"
+    "module": "Node16"
   }
 }

--- a/packages/ts-config/tsconfig.json
+++ b/packages/ts-config/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "@sapphire/ts-config/extra-strict",
   "compilerOptions": {
     "importHelpers": true,
-    "noEmitHelpers": true,
     "lib": ["ESNext"],
-    "target": "ES2021",
-    "module": "Node16"
+    "module": "Node16",
+    "noEmitHelpers": true,
+    "target": "ES2021"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -4,14 +4,6 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**"]
     },
-    "lint": {
-      "dependsOn": [],
-      "outputs": []
-    },
-    "test": {
-      "dependsOn": [],
-      "outputs": ["coverage/**"]
-    },
     "bump": {
       "dependsOn": [],
       "outputs": ["CHANGELOG.md"]
@@ -23,6 +15,14 @@
     "docs": {
       "dependsOn": [],
       "outputs": ["docs/**"]
+    },
+    "lint": {
+      "dependsOn": [],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": [],
+      "outputs": ["coverage/**"]
     }
   }
 }


### PR DESCRIPTION
- feat(eslint-config): set `curly` to default `all`
- fix(eslint-config): update `padding-line-between-statements` rule
- feat(eslint-config): set `comma-dangle` to `always-multiline`
- feat(ts-config): set `module` to `Node16` & update engine versions
- chore: sort json files
